### PR TITLE
Fix param binding bug in watershed query

### DIFF
--- a/earthenAuth_helper.php
+++ b/earthenAuth_helper.php
@@ -69,7 +69,7 @@ function getWatershedName($buwana_conn, $buwana_id) {
     $stmt_watershed = $buwana_conn->prepare($sql_watershed);
 
     if ($stmt_watershed) {
-        $stmt_watershed->bind_param('s', $buwana_id); // Assuming buwana_id is a string
+        $stmt_watershed->bind_param('i', $buwana_id); // buwana_id is numeric
         if ($stmt_watershed->execute()) {
             $stmt_watershed->bind_result($watershed_name);
             $stmt_watershed->fetch();


### PR DESCRIPTION
## Summary
- bugfix: use integer binding for buwana_id in `getWatershedName`

## Testing
- `php -l earthenAuth_helper.php` *(fails: `php` not installed)*