### PR TITLE
Add basic app creation wizard

### DIFF
--- a/en/app-wizard.php
+++ b/en/app-wizard.php
@@ -1,0 +1,128 @@
+<?php
+session_start();
+if (empty($_SESSION['buwana_id'])) {
+    header('Location: login.php');
+    exit();
+}
+
+$lang = basename(dirname($_SERVER['SCRIPT_NAME']));
+$page = 'app-wizard';
+$version = '0.1';
+$lastModified = date('Y-m-d\TH:i:s\Z', filemtime(__FILE__));
+?>
+<!DOCTYPE html>
+<html lang="<?= htmlspecialchars($lang) ?>">
+<head>
+    <meta charset="UTF-8">
+    <?php require_once("../meta/dashboard-en.php"); ?>
+    <?php require_once("../includes/buwana-index-inc.php"); ?>
+    <style>
+        .wizard-step { display:none; }
+        .wizard-step.active { display:block; }
+        .wizard-buttons { text-align:center; margin-top:20px; }
+        .wizard-buttons button { margin:0 5px; }
+    </style>
+</head>
+<body>
+<div id="form-submission-box" class="landing-page-form">
+  <div class="form-container">
+    <h1 style="text-align:center;">New App Setup</h1>
+    <form id="appWizardForm" method="post" action="../scripts/create_app.php">
+      <div id="step1" class="wizard-step active">
+        <h2>Step 1: Basic Info</h2>
+        <label>App Name<br><input type="text" name="app_name" required></label><br>
+        <label>Registration Date<br><input type="date" name="app_registration_dt" required></label><br>
+        <label>Redirect URIs<br><input type="text" name="redirect_uris" required></label><br>
+        <label>App Login URL<br><input type="text" name="app_login_url"></label><br>
+        <label>Scopes<br><input type="text" name="scopes"></label><br>
+        <label>App Domain<br><input type="text" name="app_domain"></label><br>
+        <label>App URL<br><input type="text" name="app_url"></label><br>
+        <label>App Dashboard URL<br><input type="text" name="app_dashboard_url"></label><br>
+        <label>Description<br><textarea name="app_description"></textarea></label><br>
+        <label>Version<br><input type="text" name="app_version"></label><br>
+        <label>Display Name<br><input type="text" name="app_display_name"></label><br>
+        <label>Contact Email<br><input type="email" name="contact_email"></label><br>
+      </div>
+      <div id="step2" class="wizard-step">
+        <h2>Step 2: Text Strings</h2>
+        <label>Slogan<br><input type="text" name="app_slogan"></label><br>
+        <label>Terms of Use<br><textarea name="app_terms_txt"></textarea></label><br>
+        <label>Privacy Text<br><textarea name="app_privacy_txt"></textarea></label><br>
+        <label>Emoji List (comma separated)<br><textarea name="app_emojis_array"></textarea></label><br>
+      </div>
+      <div id="step3" class="wizard-step">
+        <h2>Step 3: Basic Graphics</h2>
+        <label>Logo URL<br><input type="text" name="app_logo_url"></label><br>
+        <label>Dark Logo URL<br><input type="text" name="app_logo_dark_url"></label><br>
+        <label>Square Icon URL<br><input type="text" name="app_square_icon_url"></label><br>
+        <label>Wordmark URL<br><input type="text" name="app_wordmark_url"></label><br>
+        <label>Dark Wordmark URL<br><input type="text" name="app_wordmark_dark_url"></label><br>
+      </div>
+      <div id="step4" class="wizard-step">
+        <h2>Step 4: Signup Graphics</h2>
+        <label>Signup Top Image Light<br><input type="text" name="signup_top_img_url"></label><br>
+        <label>Signup Top Image Dark<br><input type="text" name="signup_top_img_dark_url"></label><br>
+        <label>Signup 1 Light<br><input type="text" name="signup_1_top_img_light"></label><br>
+        <label>Signup 1 Dark<br><input type="text" name="signup_1_top_img_dark"></label><br>
+        <label>Signup 2 Light<br><input type="text" name="signup_2_top_img_light"></label><br>
+        <label>Signup 2 Dark<br><input type="text" name="signup_2_top_img_dark"></label><br>
+        <label>Signup 3 Light<br><input type="text" name="signup_3_top_img_light"></label><br>
+        <label>Signup 3 Dark<br><input type="text" name="signup_3_top_img_dark"></label><br>
+        <label>Signup 4 Light<br><input type="text" name="signup_4_top_img_light"></label><br>
+        <label>Signup 4 Dark<br><input type="text" name="signup_4_top_img_dark"></label><br>
+        <label>Signup 5 Light<br><input type="text" name="signup_5_top_img_light"></label><br>
+        <label>Signup 5 Dark<br><input type="text" name="signup_5_top_img_dark"></label><br>
+        <label>Signup 6 Light<br><input type="text" name="signup_6_top_img_light"></label><br>
+        <label>Signup 6 Dark<br><input type="text" name="signup_6_top_img_dark"></label><br>
+        <label>Signup 7 Light<br><input type="text" name="signup_7_top_img_light"></label><br>
+        <label>Signup 7 Dark<br><input type="text" name="signup_7_top_img_dark"></label><br>
+        <label>Login Image Light<br><input type="text" name="login_top_img_light"></label><br>
+        <label>Login Image Dark<br><input type="text" name="login_top_img_dark"></label><br>
+      </div>
+      <div id="step5" class="wizard-step">
+        <h2>Step 5: Finish</h2>
+        <p>Review your details and submit to create the app.</p>
+      </div>
+      <div class="wizard-buttons">
+        <button type="button" id="prevBtn">Previous</button>
+        <button type="button" id="nextBtn">Next</button>
+        <button type="submit" id="submitBtn" style="display:none;">Submit</button>
+      </div>
+    </form>
+  </div>
+</div>
+<script>
+  const steps = document.querySelectorAll('.wizard-step');
+  let currentStep = 0;
+  const nextBtn = document.getElementById('nextBtn');
+  const prevBtn = document.getElementById('prevBtn');
+  const submitBtn = document.getElementById('submitBtn');
+
+  function showStep(index) {
+    steps.forEach((step,i)=>{
+      step.classList.toggle('active', i === index);
+    });
+    prevBtn.style.display = index === 0 ? 'none':'inline-block';
+    nextBtn.style.display = index === steps.length -1 ? 'none':'inline-block';
+    submitBtn.style.display = index === steps.length -1 ? 'inline-block':'none';
+  }
+
+  nextBtn.addEventListener('click', () => {
+    if(currentStep < steps.length -1){
+      currentStep++;
+      showStep(currentStep);
+    }
+  });
+
+  prevBtn.addEventListener('click', () => {
+    if(currentStep > 0){
+      currentStep--;
+      showStep(currentStep);
+    }
+  });
+
+  showStep(currentStep);
+</script>
+<?php require_once("../footer-2025.php"); ?>
+</body>
+</html>

--- a/en/dashboard.php
+++ b/en/dashboard.php
@@ -39,6 +39,9 @@ $stmt->close();
 <div id="form-submission-box" class="landing-page-form">
   <div class="form-container">
     <h1 style="text-align:center;">Buwana App Manager Dashboard</h1>
+    <div style="text-align:center;margin-bottom:20px;">
+      <a href="app-wizard.php" class="kick-ass-submit">Create New App</a>
+    </div>
     <div class="app-grid">
       <?php foreach ($apps as $app): ?>
         <div class="app-display-box">

--- a/en/view_app.php
+++ b/en/view_app.php
@@ -1,0 +1,28 @@
+<?php
+session_start();
+require_once '../fetch_app_info.php';
+
+$lang = basename(dirname($_SERVER['SCRIPT_NAME']));
+$page = 'view-app';
+$version = '0.1';
+$lastModified = date('Y-m-d\TH:i:s\Z', filemtime(__FILE__));
+
+$app_id = intval($_GET['app_id'] ?? 0);
+?>
+<!DOCTYPE html>
+<html lang="<?= htmlspecialchars($lang) ?>">
+<head>
+  <meta charset="UTF-8">
+  <?php require_once("../meta/dashboard-en.php"); ?>
+  <?php require_once("../includes/buwana-index-inc.php"); ?>
+</head>
+<body>
+<div id="form-submission-box" class="landing-page-form">
+  <div class="form-container">
+    <h1 style="text-align:center;">App Overview</h1>
+    <p>This page will display details for app ID <?= intval($app_id) ?>.</p>
+  </div>
+</div>
+<?php require_once("../footer-2025.php"); ?>
+</body>
+</html>

--- a/scripts/create_app.php
+++ b/scripts/create_app.php
@@ -1,0 +1,77 @@
+<?php
+require_once '../buwanaconn_env.php';
+session_start();
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'error' => 'Invalid request']);
+    exit();
+}
+
+$owner_id = $_SESSION['buwana_id'] ?? null;
+if (!$owner_id) {
+    echo json_encode(['success' => false, 'error' => 'Not logged in']);
+    exit();
+}
+
+function generateClientId($name) {
+    $prefix = substr(preg_replace('/[^a-zA-Z0-9]/', '', strtolower($name)), 0, 4);
+    return $prefix . '_' . bin2hex(random_bytes(6));
+}
+
+$app_name = trim($_POST['app_name'] ?? '');
+$client_id = generateClientId($app_name ?: 'app');
+$client_secret = bin2hex(random_bytes(16));
+$app_registration_dt = $_POST['app_registration_dt'] ?? date('Y-m-d H:i:s');
+
+$sql = "INSERT INTO apps_tb (
+    app_name, app_registration_dt, client_id, client_secret,
+    redirect_uris, app_login_url, scopes, app_domain, app_url,
+    app_dashboard_url, app_description, app_version, app_display_name,
+    contact_email, app_slogan, app_terms_txt, app_privacy_txt,
+    app_emojis_array, app_logo_url, app_logo_dark_url, app_square_icon_url,
+    app_wordmark_url, app_wordmark_dark_url, signup_top_img_url, signup_top_img_dark_url,
+    signup_1_top_img_light, signup_1_top_img_dark, signup_2_top_img_light, signup_2_top_img_dark,
+    signup_3_top_img_light, signup_3_top_img_dark, signup_4_top_img_light, signup_4_top_img_dark,
+    signup_5_top_img_light, signup_5_top_img_dark, signup_6_top_img_light, signup_6_top_img_dark,
+    signup_7_top_img_light, signup_7_top_img_dark, login_top_img_light, login_top_img_dark,
+    is_active, allow_signup, require_verification, last_used_dt, updated_dt, owner_buwana_id
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, 1, NOW(), NOW(), ?
+)";
+
+$stmt = $buwana_conn->prepare($sql);
+if (!$stmt) {
+    echo json_encode(['success' => false, 'error' => $buwana_conn->error]);
+    exit();
+}
+
+$params = [
+    $app_name, $app_registration_dt, $client_id, $client_secret,
+    $_POST['redirect_uris'] ?? '', $_POST['app_login_url'] ?? '', $_POST['scopes'] ?? '',
+    $_POST['app_domain'] ?? '', $_POST['app_url'] ?? '', $_POST['app_dashboard_url'] ?? '',
+    $_POST['app_description'] ?? '', $_POST['app_version'] ?? '', $_POST['app_display_name'] ?? '',
+    $_POST['contact_email'] ?? '', $_POST['app_slogan'] ?? '', $_POST['app_terms_txt'] ?? '',
+    $_POST['app_privacy_txt'] ?? '', $_POST['app_emojis_array'] ?? '',
+    $_POST['app_logo_url'] ?? '', $_POST['app_logo_dark_url'] ?? '', $_POST['app_square_icon_url'] ?? '',
+    $_POST['app_wordmark_url'] ?? '', $_POST['app_wordmark_dark_url'] ?? '', $_POST['signup_top_img_url'] ?? '',
+    $_POST['signup_top_img_dark_url'] ?? '', $_POST['signup_1_top_img_light'] ?? '', $_POST['signup_1_top_img_dark'] ?? '',
+    $_POST['signup_2_top_img_light'] ?? '', $_POST['signup_2_top_img_dark'] ?? '', $_POST['signup_3_top_img_light'] ?? '',
+    $_POST['signup_3_top_img_dark'] ?? '', $_POST['signup_4_top_img_light'] ?? '', $_POST['signup_4_top_img_dark'] ?? '',
+    $_POST['signup_5_top_img_light'] ?? '', $_POST['signup_5_top_img_dark'] ?? '', $_POST['signup_6_top_img_light'] ?? '',
+    $_POST['signup_6_top_img_dark'] ?? '', $_POST['signup_7_top_img_light'] ?? '', $_POST['signup_7_top_img_dark'] ?? '',
+    $_POST['login_top_img_light'] ?? '', $_POST['login_top_img_dark'] ?? '', $owner_id
+];
+
+$types = str_repeat('s', count($params) - 1) . 'i';
+$stmt->bind_param($types, ...$params);
+
+if ($stmt->execute()) {
+    $app_id = $stmt->insert_id;
+    $stmt->close();
+    echo json_encode(['success' => true, 'redirect' => "view_app.php?app_id=$app_id"]);
+} else {
+    $error = $stmt->error;
+    $stmt->close();
+    echo json_encode(['success' => false, 'error' => $error]);
+}


### PR DESCRIPTION
## Summary
- add a `Create New App` button to dashboard
- implement a simple multi‑step app setup wizard
- create backend stub to insert new apps
- add placeholder app overview page

## Testing
- `php -l en/app-wizard.php` *(fails: `php` not found)*