### PR TITLE
Fix app stats query for user connections

### DIFF
--- a/analytics/get-growth-data.php
+++ b/analytics/get-growth-data.php
@@ -1,10 +1,16 @@
 <?php
 require_once '../buwanaconn_env.php';
 header('Content-Type: application/json');
+
 $app_id = isset($_GET['app_id']) ? intval($_GET['app_id']) : null;
 
 if ($app_id) {
-    $sql = "SELECT DATE(connected_at) as dt, COUNT(*) as cnt FROM user_app_connections_tb WHERE app_id = ? GROUP BY DATE(connected_at) ORDER BY DATE(connected_at)";
+    $sql = "SELECT DATE(u.connected_at) as dt, COUNT(*) as cnt
+            FROM user_app_connections_tb u
+            JOIN apps_tb a ON u.client_id = a.client_id
+            WHERE a.app_id = ?
+            GROUP BY DATE(u.connected_at)
+            ORDER BY DATE(u.connected_at)";
     $stmt = $buwana_conn->prepare($sql);
     $stmt->bind_param('i', $app_id);
 } else {

--- a/en/view_app.php
+++ b/en/view_app.php
@@ -55,8 +55,8 @@ if (!$app) {
     exit();
 }
 
-$stmt = $buwana_conn->prepare("SELECT COUNT(*) FROM user_app_connections_tb WHERE app_id = ?");
-$stmt->bind_param('i', $app_id);
+$stmt = $buwana_conn->prepare("SELECT COUNT(*) FROM user_app_connections_tb WHERE client_id = ?");
+$stmt->bind_param('s', $app['client_id']);
 $stmt->execute();
 $stmt->bind_result($total_connections);
 $stmt->fetch();


### PR DESCRIPTION
## Summary
- fix counting query in `view_app.php` using `client_id`
- join `apps_tb` when filtering growth data by app ID

## Testing
- `phpunit` *(fails: command not found)*