### PR TITLE
Fix profile link and persist connection id

### DIFF
--- a/en/login_process.php
+++ b/en/login_process.php
@@ -122,20 +122,22 @@ if ($stmt_credential) {
                $stmt->close();
            }
 
-           // 🔍 Check if the user is already connected to this app
-           $check_sql = "SELECT COUNT(*) FROM user_app_connections_tb WHERE buwana_id = ? AND client_id = ?";
+           // 🔍 Check if the user is already connected to this app and grab the connection id
+           $check_sql = "SELECT id FROM user_app_connections_tb WHERE buwana_id = ? AND client_id = ? LIMIT 1";
            $check_stmt = $buwana_conn->prepare($check_sql);
            if ($check_stmt) {
                $check_stmt->bind_param('is', $buwana_id, $client_id);
                $check_stmt->execute();
-               $check_stmt->bind_result($connection_count);
+               $check_stmt->bind_result($connection_id);
                $check_stmt->fetch();
                $check_stmt->close();
 
-               if ($connection_count == 0) {
+               if (!$connection_id) {
                    // 🚪 Not yet connected → send to app-connect page
                    header("Location: app-connect.php?id=$buwana_id&client_id=$client_id");
                    exit();
+               } else {
+                   $_SESSION['connection_id'] = $connection_id;
                }
            }
        }

--- a/header-2025.php
+++ b/header-2025.php
@@ -335,8 +335,15 @@ max-height: 200px;
      <?= htmlspecialchars($earthling_emoji) ?> Logged in as <?= htmlspecialchars($first_name) ?> |
      <a href="<?= htmlspecialchars($logout_url) ?>">Log out</a>
    </div>
+   <?php
+     $profile_url = 'edit-profile.php';
+     $connection_id = $_SESSION['connection_id'] ?? null;
+     if (!empty($connection_id)) {
+         $profile_url .= '?con=' . urlencode($connection_id);
+     }
+   ?>
    <div class="menu-page-item">
-     <a href="edit-profile.php">Edit user profile</a>
+     <a href="<?= htmlspecialchars($profile_url) ?>">Edit user profile</a>
    </div>
  <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- store `connection_id` during login
- update header to link to `edit-profile.php` using `connection_id`

## Testing
- `phpunit --version` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: command not found)*