### PR TITLE
Improve error clarity for edit-profile

### DIFF
--- a/en/edit-profile.php
+++ b/en/edit-profile.php
@@ -1,5 +1,9 @@
 <?php
 require_once '../earthenAuth_helper.php';
+// Ensure the Buwana DB config is available
+if (!file_exists('../buwanaconn_env.php')) {
+    die('Buwana DB config not found.');
+}
 require_once '../buwanaconn_env.php';
 
 // Set up page variables


### PR DESCRIPTION
## Summary
- show a clearer message if the Buwana DB configuration is missing

## Testing
- `php -v` *(fails: command not found)*