### PR TITLE
Rename view_app and add status toggles

### DIFF
--- a/buwana-wiki/Buwana-App-Manager-Development-Plan.md
+++ b/buwana-wiki/Buwana-App-Manager-Development-Plan.md
@@ -200,7 +200,7 @@ Provide a page to edit, manage and delete app as well as to Visualize app's user
 - Edit and update app data
 
 **Route:**
-`/en/view_app.php?app_id=xxx`
+`/en/app-view.php?app_id=xxx`
 
 ---
 

--- a/en/dashboard.php
+++ b/en/dashboard.php
@@ -67,7 +67,7 @@ $user_app_count = count($apps);
     <p class="welcome-msg">Welcome back <?= htmlspecialchars($first_name) ?>!  You have <?= intval($new_account_count_for_user) ?> new users in the last 24hrs.  Manage your <?= $user_app_count ?> here...</p>
     <div class="app-grid">
       <?php foreach ($apps as $app): ?>
-        <a href="view_app.php?app_id=<?= intval($app['app_id']) ?>" class="app-display-box" title="<?= htmlspecialchars($app['app_display_name']) ?>">
+        <a href="app-view.php?app_id=<?= intval($app['app_id']) ?>" class="app-display-box" title="<?= htmlspecialchars($app['app_display_name']) ?>">
           <img src="<?= htmlspecialchars($app['app_square_icon_url']) ?>" alt="<?= htmlspecialchars($app['app_display_name']) ?> Icon">
           <p><?= intval($app['user_count']) ?> users</p>
         </a>

--- a/en/edit-app-core.php
+++ b/en/edit-app-core.php
@@ -72,12 +72,29 @@ if (!$app) {
 <div id="form-submission-box" class="landing-page-form">
   <div class="form-container">
     <div class="top-wrapper">
-      <div class="login-status"><?= htmlspecialchars($earthling_emoji) ?> Logged in as <?= htmlspecialchars($first_name) ?></div>
       <div>
-        <div class="page-name">Edit Core Data: <?= htmlspecialchars($app['app_display_name']) ?></div>
+        <div class="login-status"><?= htmlspecialchars($earthling_emoji) ?> Logged in as <?= htmlspecialchars($first_name) ?></div>
+        <div style="font-size:0.9em;">
+          <?php if($app['is_active']): ?>
+            🟢 <?= htmlspecialchars($app['app_display_name']) ?> is active
+          <?php else: ?>
+            ⚪ <?= htmlspecialchars($app['app_display_name']) ?> is not active
+          <?php endif; ?>
+        </div>
+        <div style="font-size:0.9em;">
+          <?php if($app['allow_signup']): ?>
+            🟢 <?= htmlspecialchars($app['app_display_name']) ?> Signups enable
+          <?php else: ?>
+            <?= htmlspecialchars($app['app_display_name']) ?> ⚪ Signups Off
+          <?php endif; ?>
+        </div>
+      </div>
+      <div>
+        <div class="page-name"><?= htmlspecialchars($app['app_display_name']) ?></div>
         <div class="client-id">Client ID: <?= htmlspecialchars($app['client_id']) ?></div>
       </div>
     </div>
+    <h4>Edit Core Data</h4>
     <p>Set the core parameters for your <?= htmlspecialchars($app['app_display_name']) ?> app.  These will set the base display and functionality for signing up, logins, redirects and log outs.</p>
     <form id="edit-core-form" method="post" style="margin-top:20px;">
       <div class="form-item float-label-group" style="border-radius:10px 10px 5px 5px;padding-bottom: 10px;">

--- a/scripts/create_app.php
+++ b/scripts/create_app.php
@@ -69,7 +69,7 @@ $stmt->bind_param($types, ...$params);
 if ($stmt->execute()) {
     $app_id = $stmt->insert_id;
     $stmt->close();
-    echo json_encode(['success' => true, 'redirect' => "view_app.php?app_id=$app_id"]);
+    echo json_encode(['success' => true, 'redirect' => "app-view.php?app_id=$app_id"]);
 } else {
     $error = $stmt->error;
     $stmt->close();


### PR DESCRIPTION
## Summary
- rename `view_app.php` to `app-view.php`
- show active and signup status in page header
- add checkboxes to toggle `is_active` and `allow_signup`
- update core editor header and add status indicators
- adjust references to the renamed page

## Testing
- `phpunit` *(fails: command not found)*