### PR TITLE
Improve app dashboard styling and toggles

### DIFF
--- a/api/update_app_flag.php
+++ b/api/update_app_flag.php
@@ -1,0 +1,27 @@
+<?php
+session_start();
+require_once '../buwanaconn_env.php';
+header('Content-Type: application/json');
+
+$buwana_id = intval($_SESSION['buwana_id'] ?? 0);
+$app_id = intval($_POST['app_id'] ?? 0);
+$field = $_POST['field'] ?? '';
+$value = isset($_POST['value']) ? intval($_POST['value']) : null;
+
+if(!$buwana_id || !$app_id || !in_array($field, ['is_active','allow_signup']) || !in_array($value,[0,1])){
+    echo json_encode(['success'=>false]);
+    exit();
+}
+
+$sql = $field === 'is_active'
+    ? 'UPDATE apps_tb SET is_active=? WHERE app_id=? AND owner_buwana_id=?'
+    : 'UPDATE apps_tb SET allow_signup=? WHERE app_id=? AND owner_buwana_id=?';
+$stmt = $buwana_conn->prepare($sql);
+$success = false;
+if($stmt){
+    $stmt->bind_param('iii',$value,$app_id,$buwana_id);
+    $success = $stmt->execute();
+    $stmt->close();
+}
+
+echo json_encode(['success'=>$success]);

--- a/en/dashboard.php
+++ b/en/dashboard.php
@@ -60,7 +60,7 @@ $user_app_count = count($apps);
       <div class="login-status"><?= htmlspecialchars($earthling_emoji) ?> Logged in as <?= htmlspecialchars($first_name) ?></div>
       <div class="page-name">App Manager Dashboard</div>
     </div>
-    <div class="chart-container">
+    <div class="chart-container dashboard-module">
       <canvas id="growthChart"></canvas>
       <p class="chart-caption">Buwana user growth over the last 30days</p>
     </div>

--- a/en/edit-app-core.php
+++ b/en/edit-app-core.php
@@ -74,16 +74,16 @@ if (!$app) {
     <div class="top-wrapper">
       <div>
         <div class="login-status"><?= htmlspecialchars($earthling_emoji) ?> Logged in as <?= htmlspecialchars($first_name) ?></div>
-        <div style="font-size:0.9em;">
+        <div style="font-size:0.9em;color:grey;">
           <?php if($app['is_active']): ?>
             🟢 <?= htmlspecialchars($app['app_display_name']) ?> is active
           <?php else: ?>
             ⚪ <?= htmlspecialchars($app['app_display_name']) ?> is not active
           <?php endif; ?>
         </div>
-        <div style="font-size:0.9em;">
+        <div style="font-size:0.9em;color:grey;">
           <?php if($app['allow_signup']): ?>
-            🟢 <?= htmlspecialchars($app['app_display_name']) ?> Signups enable
+            🟢 <?= htmlspecialchars($app['app_display_name']) ?> signups enabled
           <?php else: ?>
             <?= htmlspecialchars($app['app_display_name']) ?> ⚪ Signups Off
           <?php endif; ?>

--- a/includes/dashboard-inc.php
+++ b/includes/dashboard-inc.php
@@ -58,6 +58,9 @@
 
 .dataTables_wrapper {
   margin: 0 auto;
+}
+
+.dashboard-module {
   background: var(--form-field-background);
   padding: 20px;
   border-radius: 10px;

--- a/styles/main.css
+++ b/styles/main.css
@@ -1865,3 +1865,46 @@ Sign up process
 .modal-content-box ul {
     padding-left: 1.2em;
 }
+
+.toggle-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+}
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.toggle-switch .slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background-color: var(--toggle-off, #ccc);
+  transition: .4s;
+  border-radius: 22px;
+}
+.toggle-switch .slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  transition: .4s;
+  border-radius: 50%;
+}
+.toggle-switch input:checked + .slider {
+  background-color: var(--emblem-green);
+}
+.toggle-switch input:checked + .slider:before {
+  transform: translateX(18px);
+}

--- a/styles/mode-dark.css
+++ b/styles/mode-dark.css
@@ -10,6 +10,7 @@
   --same: black;
   --text-color: rgb(230, 231, 242);
   --subdued-text: rgb(158, 162, 184);
+  --toggle-off: var(--subdued-text);
   --logo-color: rgb(213, 213, 213);
   --top-header: #21232f;
   --top-header-main: #21232fbf;
@@ -714,4 +715,8 @@ background: url(../webps/brikchain-450px.webp) no-repeat center;
 .earthen-subs-top {
     background: url(../svgs/earthen-subscribe-top-day.svg) no-repeat center;
     background-size: contain;
+}
+
+.toggle-switch .slider {
+  background-color: var(--toggle-off);
 }

--- a/styles/mode-light.css
+++ b/styles/mode-light.css
@@ -9,7 +9,8 @@
     --main-background: white;
     --text-color: #242424;
     --same: white;
-    --subdued-text: #454545;
+   --subdued-text: #454545;
+    --toggle-off: var(--subdued-text);
     --logo-color: #666;
     --top-header: #fff;
     --top-header-main: #ffffffbf;
@@ -569,6 +570,10 @@ background: url(../webps/brikchain-450px.webp) no-repeat center;
 .earthen-subs-top {
     background: url(../svgs/earthen-subscribe-top-day.svg) no-repeat center;
     background-size: contain;
+}
+
+.toggle-switch .slider {
+    background-color: var(--toggle-off);
 }
 
 /* Light mode pastel colors */


### PR DESCRIPTION
## Summary
- add reusable `dashboard-module` container style
- switch to AJAX toggles for app activation and signup
- apply dashboard module to chart containers and tables
- create dark/light toggle styling

## Testing
- `phpunit -c phpunit.xml` *(fails: command not found)*