### PR TITLE
Add top-wrapper styles and breadcrumbs

### DIFF
--- a/en/edit-app-core.php
+++ b/en/edit-app-core.php
@@ -114,6 +114,11 @@ if (!$app) {
         <img src="<?= htmlspecialchars($app['app_square_icon_url']) ?>" alt="<?= htmlspecialchars($app['app_display_name']) ?> Icon" title="<?= htmlspecialchars($app['app_display_name']) ?>" width="50" height="50">
       </div>
     </div>
+    <div class="breadcrumb">
+      <a href="dashboard.php">Dashboard</a> &gt; 
+      <a href="app-view.php?app_id=<?= intval($app_id) ?>">Manage <?= htmlspecialchars($app['app_display_name']) ?></a> &gt; 
+      Edit Core
+    </div>
     <h1 data-lang-id="000-edit-core-date">Edit Core Data</h1>
     <p>Set the core parameters for your <?= htmlspecialchars($app['app_display_name']) ?> app.  These will set the base display and functionality for signing up, logins, redirects and log outs.</p>
     <form id="edit-core-form" method="post" style="margin-top:20px;">

--- a/en/edit-app-graphics.php
+++ b/en/edit-app-graphics.php
@@ -72,8 +72,13 @@ if (!$app) {
         <div class="page-name">Edit App Graphics: <?= htmlspecialchars($app['app_display_name']) ?></div>
         <div class="client-id">Client ID: <?= htmlspecialchars($app['client_id']) ?></div>
       </div>
-    </div>
-    <form method="post" style="margin-top:20px;">
+      </div>
+      <div class="breadcrumb">
+        <a href="dashboard.php">Dashboard</a> &gt; 
+        <a href="app-view.php?app_id=<?= intval($app_id) ?>">Manage <?= htmlspecialchars($app['app_display_name']) ?></a> &gt; 
+        Edit Graphics
+      </div>
+      <form method="post" style="margin-top:20px;">
       <label>Logo URL (light)<br>
         <input type="text" name="app_logo_url" value="<?= htmlspecialchars($app['app_logo_url']) ?>">
       </label><br><br>

--- a/en/edit-app-signup.php
+++ b/en/edit-app-signup.php
@@ -86,6 +86,11 @@ if (!$app) {
         <div class="client-id">Client ID: <?= htmlspecialchars($app['client_id']) ?></div>
       </div>
     </div>
+    <div class="breadcrumb">
+      <a href="dashboard.php">Dashboard</a> &gt; 
+      <a href="app-view.php?app_id=<?= intval($app_id) ?>">Manage <?= htmlspecialchars($app['app_display_name']) ?></a> &gt; 
+      Edit Signup Graphics
+    </div>
     <form method="post" style="margin-top:20px;">
       <label>Signup Banner Light<br>
         <input type="text" name="signup_top_img_url" value="<?= htmlspecialchars($app['signup_top_img_url']) ?>">

--- a/en/edit-app-texts.php
+++ b/en/edit-app-texts.php
@@ -71,8 +71,13 @@ if (!$app) {
         <div class="page-name">Edit App Texts: <?= htmlspecialchars($app['app_display_name']) ?></div>
         <div class="client-id">Client ID: <?= htmlspecialchars($app['client_id']) ?></div>
       </div>
-    </div>
-    <form method="post" style="margin-top:20px;">
+      </div>
+      <div class="breadcrumb">
+        <a href="dashboard.php">Dashboard</a> &gt; 
+        <a href="app-view.php?app_id=<?= intval($app_id) ?>">Manage <?= htmlspecialchars($app['app_display_name']) ?></a> &gt; 
+        Edit Texts
+      </div>
+      <form method="post" style="margin-top:20px;">
       <label>App Slogan<br>
         <input type="text" name="app_slogan" value="<?= htmlspecialchars($app['app_slogan']) ?>">
       </label><br><br>

--- a/includes/dashboard-inc.php
+++ b/includes/dashboard-inc.php
@@ -31,6 +31,10 @@
   align-items: center;
   height: auto;
   margin-bottom: 20px;
+  padding: 15px;
+  background: #ffffff0d;
+  border-radius: 10px;
+  line-height: 1.5;
 }
 
 .login-status {
@@ -154,6 +158,31 @@
   justify-content: center;
   gap: 10px;
   flex-wrap: wrap;
+}
+
+.breadcrumb {
+  text-align: right;
+  font-family: 'Mulish', Arial, Helvetica, sans-serif;
+  font-size: 1em;
+  color: grey;
+  margin-top: 5px;
+  margin-bottom: 20px;
+}
+
+.breadcrumb a {
+  color: grey;
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+  .top-wrapper .page-name,
+  .top-wrapper .client-id {
+    display: none;
+  }
 }
 
 </style>


### PR DESCRIPTION
## Summary
- style `.top-wrapper` with padding, border radius and background
- hide the app name and client id on narrow screens
- add breadcrumb nav to the app edit pages

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: no such file or directory)*