### PR TITLE
Enhance dashboard chart

### DIFF
--- a/analytics/get-user-growth.php
+++ b/analytics/get-user-growth.php
@@ -2,16 +2,48 @@
 require_once '../buwanaconn_env.php';
 header('Content-Type: application/json');
 
-$days = 30;
+$range = $_GET['range'] ?? 'month';
 $labels = [];
 $data = [];
 
+switch ($range) {
+    case '24h':
+        $periods = 24; // hours
+        $increment = 'hour';
+        $groupSql = "DATE_FORMAT(created_at, '%Y-%m-%d %H:00:00')";
+        $labelFormat = 'Y-m-d H:00';
+        $chartLabel = 'Buwana total users over the last 24 hours';
+        break;
+    case 'week':
+        $periods = 7;
+        $increment = 'day';
+        $groupSql = "DATE(created_at)";
+        $labelFormat = 'Y-m-d';
+        $chartLabel = 'Buwana total users over the last week';
+        break;
+    case 'year':
+        $periods = 12; // months
+        $increment = 'month';
+        $groupSql = "DATE_FORMAT(created_at, '%Y-%m')";
+        $labelFormat = 'Y-m';
+        $chartLabel = 'Buwana total users over the last year';
+        break;
+    case 'month':
+    default:
+        $periods = 30;
+        $increment = 'day';
+        $groupSql = "DATE(created_at)";
+        $labelFormat = 'Y-m-d';
+        $chartLabel = 'Buwana total users over the last 30 days';
+        break;
+}
+
 $startDate = new DateTime();
-$startDate->modify('-' . ($days - 1) . ' days');
-$initialDate = $startDate->format('Y-m-d');
+$startDate->modify('-' . ($periods - 1) . ' ' . $increment . 's');
+$initialDate = $startDate->format('Y-m-d H:i:s');
 
 // Total users before the range
-$stmt = $buwana_conn->prepare("SELECT COUNT(*) FROM users_tb WHERE DATE(created_at) < ?");
+$stmt = $buwana_conn->prepare("SELECT COUNT(*) FROM users_tb WHERE created_at < ?");
 $stmt->bind_param('s', $initialDate);
 $stmt->execute();
 $stmt->bind_result($total);
@@ -19,8 +51,8 @@ $stmt->fetch();
 $stmt->close();
 $currentTotal = (int)$total;
 
-// New signups per day for the range
-$stmt = $buwana_conn->prepare("SELECT DATE(created_at) as dt, COUNT(*) as cnt FROM users_tb WHERE created_at >= ? GROUP BY DATE(created_at) ORDER BY DATE(created_at)");
+// New signups aggregated for the range
+$stmt = $buwana_conn->prepare("SELECT $groupSql as dt, COUNT(*) as cnt FROM users_tb WHERE created_at >= ? GROUP BY dt ORDER BY dt");
 $stmt->bind_param('s', $initialDate);
 $stmt->execute();
 $result = $stmt->get_result();
@@ -30,11 +62,18 @@ while ($row = $result->fetch_assoc()) {
 }
 $stmt->close();
 
-for ($i = 0; $i < $days; $i++) {
-    $date = clone $startDate;
-    $date->modify('+' . $i . ' days');
-    $label = $date->format('Y-m-d');
-    $currentTotal += $signups[$label] ?? 0;
+for ($i = 0; $i < $periods; $i++) {
+    $point = clone $startDate;
+    $point->modify('+' . $i . ' ' . $increment);
+    if ($increment === 'month') {
+        $key = $point->format('Y-m');
+    } elseif ($increment === 'hour') {
+        $key = $point->format('Y-m-d H:00:00');
+    } else {
+        $key = $point->format('Y-m-d');
+    }
+    $label = $point->format($labelFormat);
+    $currentTotal += $signups[$key] ?? 0;
     $labels[] = $label;
     $data[] = $currentTotal;
 }
@@ -42,7 +81,7 @@ for ($i = 0; $i < $days; $i++) {
 echo json_encode([
     'labels' => $labels,
     'datasets' => [[
-        'label' => 'Buwana total users over the last 30 days',
+        'label' => $chartLabel,
         'data' => $data,
         'fill' => false,
         'borderColor' => '#36a2eb'

--- a/en/dashboard.php
+++ b/en/dashboard.php
@@ -96,6 +96,14 @@ if ($alert_count > 0) {
     </div>
     <div class="chart-container dashboard-module">
       <canvas id="growthChart"></canvas>
+      <div class="chart-controls">
+        <select id="timeRange">
+          <option value="24h">Last 24hrs</option>
+          <option value="week">Last Week</option>
+          <option value="month" selected>Last Month</option>
+          <option value="year">Last Year</option>
+        </select>
+      </div>
     </div>
     <p class="welcome-msg" style="text-align: center;">Welcome back <?= htmlspecialchars($first_name) ?>!  You have <?= intval($new_account_count_for_user) ?> new users in the last 24hrs.  Manage your <?= $user_app_count ?> apps here...</p>
     <div class="app-grid">
@@ -114,32 +122,37 @@ if ($alert_count > 0) {
 </div>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-  fetch('../analytics/get-user-growth.php')
-    .then(r => r.json())
-    .then(chartData => {
-      chartData.labels = chartData.labels.map(dt => dt.slice(5));
-      new Chart(document.getElementById('growthChart'), {
-        type: 'line',
-        data: chartData,
-        options: {
-          responsive: true,
-          plugins: {
-            legend: {
-              position: 'bottom',
-              labels: { color: 'var(--text-color)' }
+  Chart.defaults.color = 'var(--subdued-text)';
+  const ctx = document.getElementById('growthChart').getContext('2d');
+  let growthChart;
+
+  function loadChart(range = 'month') {
+    fetch('../analytics/get-user-growth.php?range=' + range)
+      .then(r => r.json())
+      .then(chartData => {
+        if (growthChart) {
+          growthChart.data = chartData;
+          growthChart.update();
+        } else {
+          growthChart = new Chart(ctx, {
+            type: 'line',
+            data: chartData,
+            options: {
+              responsive: true,
+              plugins: {
+                legend: { position: 'bottom' }
+              }
             }
-          },
-          scales: {
-            x: {
-              ticks: { color: 'var(--subdued-text)' }
-            },
-            y: {
-              ticks: { color: 'var(--subdued-text)' }
-            }
-          }
+          });
         }
       });
-    });
+  }
+
+  document.getElementById('timeRange').addEventListener('change', function() {
+    loadChart(this.value);
+  });
+
+  loadChart();
 });
 </script>
 <?php require_once("../footer-2025.php"); ?>

--- a/includes/dashboard-inc.php
+++ b/includes/dashboard-inc.php
@@ -64,6 +64,13 @@
 .chart-container {
   width: 100%;
   margin: 0 auto;
+  position: relative;
+}
+
+.chart-controls {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
 }
 
 .dataTables_wrapper {


### PR DESCRIPTION
## Summary
- add a `range` option to `get-user-growth.php` for various time periods
- add bottom-right range selector for growth chart
- set global chart text color and hook selector to reload data
- tweak dashboard styles to position the selector

## Testing
- `vendor/bin/phpunit` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_683d5923924c8323bbcc8350f9d3d9ef