### PR TITLE
Fix chart text color update with theme switch

### DIFF
--- a/en/dashboard.php
+++ b/en/dashboard.php
@@ -124,8 +124,9 @@ if ($alert_count > 0) {
 </div>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-  const rootStyles = getComputedStyle(document.documentElement);
-  Chart.defaults.color = rootStyles.getPropertyValue('--subdued-text').trim();
+  if (typeof updateChartTextColor === 'function') {
+    updateChartTextColor();
+  }
 
   const ctx = document.getElementById('growthChart').getContext('2d');
   let growthChart;

--- a/scripts/core-2025.js
+++ b/scripts/core-2025.js
@@ -281,15 +281,25 @@ function openModal(contentHtml) {
     }
 }
 
-// Apply global Chart.js text color from theme variables
-document.addEventListener('DOMContentLoaded', () => {
+// Update Chart.js text color from the current theme
+function updateChartTextColor() {
     if (window.Chart && Chart.defaults) {
         const styles = getComputedStyle(document.documentElement);
-        const subdued = styles.getPropertyValue('--h1').trim();
-        if (subdued) {
-            Chart.defaults.color = subdued;
+        const color = styles.getPropertyValue('--h1').trim();
+        if (color) {
+            Chart.defaults.color = color;
+            if (Chart.instances) {
+                Object.values(Chart.instances).forEach(ch => {
+                    ch.options.color = color;
+                    ch.update();
+                });
+            }
         }
     }
-});
+}
+
+// Apply global Chart.js text color from theme variables
+document.addEventListener('DOMContentLoaded', updateChartTextColor);
+document.addEventListener('colorschemechange', updateChartTextColor);
 
 


### PR DESCRIPTION
## Summary
- ensure Chart.js text color uses --h1
- update charts when theme changes

## Testing
- `phpunit --configuration phpunit.xml tests` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683d69a9a4608323b59d2f9854d46bb0