### PR TITLE
Apply edit-app-core improvements to other edit pages

### DIFF
--- a/en/edit-app-graphics.php
+++ b/en/edit-app-graphics.php
@@ -30,6 +30,9 @@ if ($stmt) {
     $stmt->close();
 }
 
+$success = false;
+$error_message = '';
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_app'])) {
     $app_logo_url        = $_POST['app_logo_url'] ?? '';
     $app_logo_dark_url   = $_POST['app_logo_dark_url'] ?? '';
@@ -40,9 +43,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_app'])) {
     $sql = "UPDATE apps_tb SET app_logo_url=?, app_logo_dark_url=?, app_square_icon_url=?, app_wordmark_url=?, app_wordmark_dark_url=? WHERE app_id=? AND owner_buwana_id=?";
     $stmt = $buwana_conn->prepare($sql);
     if ($stmt) {
-        $stmt->bind_param('ssssssi', $app_logo_url, $app_logo_dark_url, $app_square_icon_url, $app_wordmark_url, $app_wordmark_dark_url, $app_id, $buwana_id);
-        $stmt->execute();
+        if ($stmt->bind_param('ssssssi', $app_logo_url, $app_logo_dark_url, $app_square_icon_url, $app_wordmark_url, $app_wordmark_dark_url, $app_id, $buwana_id)) {
+            $success = $stmt->execute();
+            if (!$success) {
+                $error_message = $stmt->error;
+            }
+        } else {
+            $error_message = $stmt->error;
+        }
         $stmt->close();
+    } else {
+        $error_message = $buwana_conn->error;
+    }
+
+    if (isset($_GET['ajax'])) {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => $success, 'error' => $error_message]);
+        exit();
     }
 }
 
@@ -106,6 +123,10 @@ if (!$app) {
       </div>
 
     </div>
+            <div id="update-status" style="font-size:1.3em; color:green;padding:10px;margin-top:10px;"></div>
+            <div id="update-error" style="font-size:1.3em; color:red;padding:10px;margin-top:10px;"></div>
+    <h1>Edit App Graphics</h1>
+    <p>Manage the image URLs used for your <?= htmlspecialchars($app['app_display_name']) ?> app.</p>
       <form id="edit-graphics-form" method="post" style="margin-top:20px;">
       <div class="form-item float-label-group" style="border-radius:10px 10px 5px 5px;padding-bottom: 10px;">
         <input type="text" id="app_logo_url" name="app_logo_url" aria-label="Logo URL (light)" maxlength="255" required placeholder=" " value="<?= htmlspecialchars($app['app_logo_url']) ?>">
@@ -163,6 +184,19 @@ document.addEventListener('DOMContentLoaded', function () {
   const form = document.getElementById('edit-graphics-form');
   const fields = ['app_logo_url','app_logo_dark_url','app_square_icon_url','app_wordmark_url','app_wordmark_dark_url'];
 
+  function updateStatusMessage(success, message = '') {
+    const statusEl = document.getElementById('update-status');
+    const errorEl = document.getElementById('update-error');
+    statusEl.textContent = '';
+    errorEl.textContent = '';
+    if (success) {
+      statusEl.textContent = '✅ App updated!';
+    } else {
+      errorEl.textContent = '😭 There was a problem: ' + message;
+    }
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
   function hasInvalidChars(value) {
     return /[\'"<>]/.test(value);
   }
@@ -192,11 +226,27 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   form.addEventListener('submit', function (e) {
+    e.preventDefault();
     let allValid = true;
     fields.forEach(f => { if (!validateField(f)) allValid = false; });
     if (!allValid) {
-      e.preventDefault();
+      return;
     }
+
+    const formData = new FormData(form);
+    formData.append('update_app', '1');
+    fetch('edit_appgraphics_process.php?app_id=<?= intval($app_id) ?>', {
+      method: 'POST',
+      body: formData
+    }).then(r => r.json()).then(d => {
+      if (d.success) {
+        updateStatusMessage(true);
+      } else {
+        updateStatusMessage(false, d.error || 'Unknown error');
+      }
+    }).catch(err => {
+      updateStatusMessage(false, err.message);
+    });
   });
 });
 </script>

--- a/en/edit_appgraphics_process.php
+++ b/en/edit_appgraphics_process.php
@@ -1,0 +1,51 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+session_start();
+
+require_once '../buwanaconn_env.php';
+require_once '../fetch_app_info.php';
+
+header('Content-Type: application/json');
+
+if (empty($_SESSION['buwana_id'])) {
+    echo json_encode(['success' => false, 'error' => 'User not logged in']);
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['update_app'])) {
+    echo json_encode(['success' => false, 'error' => 'Invalid request']);
+    exit();
+}
+
+$buwana_id = intval($_SESSION['buwana_id']);
+$app_id    = isset($_GET['app_id']) ? intval($_GET['app_id']) : 0;
+
+$app_logo_url        = $_POST['app_logo_url'] ?? '';
+$app_logo_dark_url   = $_POST['app_logo_dark_url'] ?? '';
+$app_square_icon_url = $_POST['app_square_icon_url'] ?? '';
+$app_wordmark_url    = $_POST['app_wordmark_url'] ?? '';
+$app_wordmark_dark_url = $_POST['app_wordmark_dark_url'] ?? '';
+
+$success = false;
+$error_message = '';
+
+$sql = "UPDATE apps_tb SET app_logo_url=?, app_logo_dark_url=?, app_square_icon_url=?, app_wordmark_url=?, app_wordmark_dark_url=? WHERE app_id=? AND owner_buwana_id=?";
+$stmt = $buwana_conn->prepare($sql);
+if ($stmt) {
+    if ($stmt->bind_param('ssssssi', $app_logo_url, $app_logo_dark_url, $app_square_icon_url, $app_wordmark_url, $app_wordmark_dark_url, $app_id, $buwana_id)) {
+        $success = $stmt->execute();
+        if (!$success) {
+            $error_message = $stmt->error;
+        }
+    } else {
+        $error_message = $stmt->error;
+    }
+    $stmt->close();
+} else {
+    $error_message = $buwana_conn->error;
+}
+
+echo json_encode(['success' => $success, 'error' => $error_message]);
+exit();
+?>

--- a/en/edit_appsignup_process.php
+++ b/en/edit_appsignup_process.php
@@ -1,0 +1,64 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+session_start();
+
+require_once '../buwanaconn_env.php';
+require_once '../fetch_app_info.php';
+
+header('Content-Type: application/json');
+
+if (empty($_SESSION['buwana_id'])) {
+    echo json_encode(['success' => false, 'error' => 'User not logged in']);
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['update_app'])) {
+    echo json_encode(['success' => false, 'error' => 'Invalid request']);
+    exit();
+}
+
+$buwana_id = intval($_SESSION['buwana_id']);
+$app_id    = isset($_GET['app_id']) ? intval($_GET['app_id']) : 0;
+
+$signup_top_img_url      = $_POST['signup_top_img_url'] ?? '';
+$signup_top_img_dark_url = $_POST['signup_top_img_dark_url'] ?? '';
+$signup_1_top_img_light  = $_POST['signup_1_top_img_light'] ?? '';
+$signup_1_top_img_dark   = $_POST['signup_1_top_img_dark'] ?? '';
+$signup_2_top_img_light  = $_POST['signup_2_top_img_light'] ?? '';
+$signup_2_top_img_dark   = $_POST['signup_2_top_img_dark'] ?? '';
+$signup_3_top_img_light  = $_POST['signup_3_top_img_light'] ?? '';
+$signup_3_top_img_dark   = $_POST['signup_3_top_img_dark'] ?? '';
+$signup_4_top_img_light  = $_POST['signup_4_top_img_light'] ?? '';
+$signup_4_top_img_dark   = $_POST['signup_4_top_img_dark'] ?? '';
+$signup_5_top_img_light  = $_POST['signup_5_top_img_light'] ?? '';
+$signup_5_top_img_dark   = $_POST['signup_5_top_img_dark'] ?? '';
+$signup_6_top_img_light  = $_POST['signup_6_top_img_light'] ?? '';
+$signup_6_top_img_dark   = $_POST['signup_6_top_img_dark'] ?? '';
+$signup_7_top_img_light  = $_POST['signup_7_top_img_light'] ?? '';
+$signup_7_top_img_dark   = $_POST['signup_7_top_img_dark'] ?? '';
+$login_top_img_light     = $_POST['login_top_img_light'] ?? '';
+$login_top_img_dark      = $_POST['login_top_img_dark'] ?? '';
+
+$success = false;
+$error_message = '';
+
+$sql = "UPDATE apps_tb SET signup_top_img_url=?, signup_top_img_dark_url=?, signup_1_top_img_light=?, signup_1_top_img_dark=?, signup_2_top_img_light=?, signup_2_top_img_dark=?, signup_3_top_img_light=?, signup_3_top_img_dark=?, signup_4_top_img_light=?, signup_4_top_img_dark=?, signup_5_top_img_light=?, signup_5_top_img_dark=?, signup_6_top_img_light=?, signup_6_top_img_dark=?, signup_7_top_img_light=?, signup_7_top_img_dark=?, login_top_img_light=?, login_top_img_dark=? WHERE app_id=? AND owner_buwana_id=?";
+$stmt = $buwana_conn->prepare($sql);
+if ($stmt) {
+    if ($stmt->bind_param('ssssssssssssssssssii', $signup_top_img_url, $signup_top_img_dark_url, $signup_1_top_img_light, $signup_1_top_img_dark, $signup_2_top_img_light, $signup_2_top_img_dark, $signup_3_top_img_light, $signup_3_top_img_dark, $signup_4_top_img_light, $signup_4_top_img_dark, $signup_5_top_img_light, $signup_5_top_img_dark, $signup_6_top_img_light, $signup_6_top_img_dark, $signup_7_top_img_light, $signup_7_top_img_dark, $login_top_img_light, $login_top_img_dark, $app_id, $buwana_id)) {
+        $success = $stmt->execute();
+        if (!$success) {
+            $error_message = $stmt->error;
+        }
+    } else {
+        $error_message = $stmt->error;
+    }
+    $stmt->close();
+} else {
+    $error_message = $buwana_conn->error;
+}
+
+echo json_encode(['success' => $success, 'error' => $error_message]);
+exit();
+?>

--- a/en/edit_apptexts_process.php
+++ b/en/edit_apptexts_process.php
@@ -1,0 +1,50 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+session_start();
+
+require_once '../buwanaconn_env.php';
+require_once '../fetch_app_info.php';
+
+header('Content-Type: application/json');
+
+if (empty($_SESSION['buwana_id'])) {
+    echo json_encode(['success' => false, 'error' => 'User not logged in']);
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['update_app'])) {
+    echo json_encode(['success' => false, 'error' => 'Invalid request']);
+    exit();
+}
+
+$buwana_id = intval($_SESSION['buwana_id']);
+$app_id    = isset($_GET['app_id']) ? intval($_GET['app_id']) : 0;
+
+$app_slogan      = $_POST['app_slogan'] ?? '';
+$app_terms_txt   = $_POST['app_terms_txt'] ?? '';
+$app_privacy_txt = $_POST['app_privacy_txt'] ?? '';
+$app_emojis_array = $_POST['app_emojis_array'] ?? '';
+
+$success = false;
+$error_message = '';
+
+$sql = "UPDATE apps_tb SET app_slogan=?, app_terms_txt=?, app_privacy_txt=?, app_emojis_array=? WHERE app_id=? AND owner_buwana_id=?";
+$stmt = $buwana_conn->prepare($sql);
+if ($stmt) {
+    if ($stmt->bind_param('ssssii', $app_slogan, $app_terms_txt, $app_privacy_txt, $app_emojis_array, $app_id, $buwana_id)) {
+        $success = $stmt->execute();
+        if (!$success) {
+            $error_message = $stmt->error;
+        }
+    } else {
+        $error_message = $stmt->error;
+    }
+    $stmt->close();
+} else {
+    $error_message = $buwana_conn->error;
+}
+
+echo json_encode(['success' => $success, 'error' => $error_message]);
+exit();
+?>


### PR DESCRIPTION
## Summary
- introduce server-side processes `edit_appgraphics_process.php`, `edit_appsignup_process.php`, and `edit_apptexts_process.php`
- add success/error messaging and headings to edit pages
- use AJAX in edit pages to submit to new process handlers

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_683d6ad5d2b88323b5799679991b99fc