### PR TITLE
Fix edit-profile header DB connection error

### DIFF
--- a/en/edit-profile.php
+++ b/en/edit-profile.php
@@ -137,9 +137,6 @@ $user_location_watershed = $location_watershed;
 $user_location_lat = $latitude;
 $user_location_long = $longitude;
 
-// 🛑 Close connection
-$buwana_conn->close();
-
 echo '<!DOCTYPE html>
 <html lang="' . htmlspecialchars($lang, ENT_QUOTES, 'UTF-8') . '">
 <head>


### PR DESCRIPTION
## Summary
- prevent closing DB connection before including header on `edit-profile.php`

## Testing
- `phpunit tests/EarthenAuthHelperTest.php` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683d773b0bac8323997a93ef78887836