### PR TITLE
Add hover login/signup buttons

### DIFF
--- a/en/index.php
+++ b/en/index.php
@@ -49,17 +49,23 @@ if ($app_results && $app_results->num_rows > 0) {
     <p data-lang-id="002-just-starting" style="text-align:center;">The Buwana protocol provides the a user authentication alternative for apps that want to escape corporate logins for an ecoystem of resonant, green for-Earth enterprises. The Buwana protocol has only just launched as of June 2025.  Here's the apps that are using it so far...</p>
     <div class="app-grid">
       <?php foreach ($apps as $app):
-          $client_id = urlencode($app['client_id']);
-          $link = "login.php?app=$client_id";
+          $client_id  = urlencode($app['client_id']);
+          $login_link = $app['app_login_url'];
           if ($buwana_id) {
-              $link .= "&id=$buwana_id";
+              $connector = strpos($login_link, '?') === false ? '?' : '&';
+              $login_link .= $connector . 'id=' . $buwana_id;
           }
+          $signup_link = "signup-1.php?app=$client_id";
       ?>
-        <a href="<?= htmlspecialchars($link) ?>" class="app-display-box">
+        <div class="app-display-box">
           <img src="<?= htmlspecialchars($app['app_square_icon_url']) ?>" alt="<?= htmlspecialchars($app['app_display_name']) ?> Icon">
           <h4><?= htmlspecialchars($app['app_display_name']) ?></h4>
-          <p><?= htmlspecialchars($app['app_slogan']) ?></p>
-        </a>
+          <p class="app-slogan"><?= htmlspecialchars($app['app_slogan']) ?></p>
+          <div class="app-actions">
+            <a href="<?= htmlspecialchars($login_link) ?>" class="simple-button">Login</a>
+            <a href="<?= htmlspecialchars($signup_link) ?>" class="simple-button">Signup</a>
+          </div>
+        </div>
       <?php endforeach; ?>
     </div>
 
@@ -75,5 +81,18 @@ if ($app_results && $app_results->num_rows > 0) {
 </div>
 
 <?php require_once("../footer-2025.php"); ?>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const boxes = document.querySelectorAll('.app-display-box');
+    boxes.forEach(box => {
+      box.addEventListener('click', function (e) {
+        if (window.innerWidth <= 600 && !e.target.closest('.app-actions')) {
+          e.preventDefault();
+          this.classList.toggle('active');
+        }
+      });
+    });
+  });
+</script>
 </body>
 </html>

--- a/includes/buwana-index-inc.php
+++ b/includes/buwana-index-inc.php
@@ -46,6 +46,7 @@
 }
 
 .app-display-box {
+  position: relative;
   border: 1px solid var(--subdued-text);
   background-color: var(--lighter);
   border-radius: 12px;
@@ -55,6 +56,7 @@
   cursor: pointer;
   box-shadow: 0 1px 5px rgba(0,0,0,0.06);
   text-decoration: none !important;
+  overflow: hidden;
 }
 
 .app-display-box:hover {
@@ -80,6 +82,33 @@
   font-size: 0.9em;
   color: var(--subdued-text);
   margin: 0;
+  transition: opacity 0.3s ease;
+}
+
+.app-actions {
+  display: none;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.app-display-box:hover .app-actions,
+.app-display-box.active .app-actions {
+  display: flex;
+}
+
+.app-display-box:hover .app-slogan,
+.app-display-box.active .app-slogan {
+  opacity: 0;
+}
+
+.simple-button {
+  display: inline-block;
+  padding: 8px 16px;
+  background: var(--button-2-2);
+  color: white;
+  border-radius: 6px;
+  text-decoration: none;
 }
 
 </style>


### PR DESCRIPTION
## Summary
- update app grid login links to use each app's login URL
- only fade slogan on hover and show login/signup buttons
- add mobile click support for showing actions

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e6d664ed483239783c044c702284a