### PR TITLE
Fix logout redirect and breadcrumb style

### DIFF
--- a/en/edit-app-core.php
+++ b/en/edit-app-core.php
@@ -31,7 +31,7 @@ $scope_descriptions = [
 ];
 
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
-$page = 'edit-app-core';
+$page = 'edit-app-core.php';
 $version = '0.11';
 $lastModified = date('Y-m-d\TH:i:s\Z', filemtime(__FILE__));
 
@@ -194,14 +194,14 @@ if (!$app) {
                 </div>
                 <img src="<?= htmlspecialchars($app['app_square_icon_url']) ?>" alt="<?= htmlspecialchars($app['app_display_name']) ?> Icon" title="<?= htmlspecialchars($app['app_display_name']) ?>" width="60" height="60">
           </div>
-            <div class="breadcrumb" style="margin-left:auto;">
+      </div>
+
+    </div>
+    <div class="breadcrumb" style="text-align:right;margin-left:auto;">
                           <a href="dashboard.php">Dashboard</a> &gt;
                           <a href="app-view.php?app_id=<?= intval($app_id) ?>">Manage <?= htmlspecialchars($app['app_display_name']) ?></a> &gt;
                           Edit Core
                         </div>
-      </div>
-
-    </div>
             <div id="update-status" style="font-size:1.3em; color:green;padding:10px;margin-top:10px;"></div>
             <div id="update-error" style="font-size:1.3em; color:red;padding:10px;margin-top:10px;"></div>
     <h2 data-lang-id="000-edit-core-date" style="martoin">Edit Core Data</h2>
@@ -232,7 +232,24 @@ if (!$app) {
   $all_profile = count(array_intersect($profile_scopes, $selected_scopes)) === count($profile_scopes);
 ?>
 
-              <span><b><?= htmlspecialchars($scope) ?></b> ℹ️</span>
+          <div class="scope-row">
+            <div class="scope-info">
+              <span>🌐 <b>Buwana Profile</b></span>
+              <span class="scope-caption">Essential user data for logging in and using the app</span>
+              <span class="scope-subscopes">openId, Name, email, profile, phone, buwana:earthlingEmoji, buwana:location_continent</span>
+            </div>
+            <label class="toggle-switch">
+              <input type="checkbox" class="scope-checkbox scope-group" data-scopes="<?= implode(',', $profile_scopes) ?>" <?= $all_profile ? 'checked' : '' ?> />
+              <span class="slider"></span>
+            </label>
+<?php foreach ($profile_scopes as $sc): ?>
+            <input type="checkbox" class="scope-checkbox hidden-scope" name="scopes[]" value="<?= htmlspecialchars($sc) ?>" <?= in_array($sc, $selected_scopes) ? 'checked' : '' ?> style="display:none;" />
+<?php endforeach; ?>
+          </div>
+<?php foreach ([ 'buwana:community', 'buwana:bioregion' ] as $scope): ?>
+          <div class="scope-row">
+            <div class="scope-info">
+              <span>ℹ️ <b><?= htmlspecialchars($scope) ?></b></span>
               <span class="scope-caption">
                 <?= htmlspecialchars($scope_descriptions[$scope] ?? '') ?>
               </span>

--- a/header-2025.php
+++ b/header-2025.php
@@ -338,6 +338,9 @@ max-height: 200px;
     if (!empty($client_id)) {
         $params[] = 'app=' . urlencode($client_id);
     }
+    if (!empty($page)) {
+        $params[] = 'redirect=' . urlencode($page);
+    }
 
     if (!empty($params)) {
         $logout_url .= '?' . implode('&', $params);

--- a/includes/dashboard-inc.php
+++ b/includes/dashboard-inc.php
@@ -173,21 +173,22 @@
   flex-wrap: wrap;
 }
 
-.breadcrumb {
+  .breadcrumb {
   text-align: right;
   font-family: 'Mulish', Arial, Helvetica, sans-serif;
   font-size: 1em;
-  color: grey;
-  margin-top: 5px;
+  color: var(--subdued-text);
   margin-top: 20px;
 }
 
-.breadcrumb a {
-  color: grey;
+  .breadcrumb a {
+  color: var(--subdued-text);
   text-decoration: none;
+  transition: color 0.2s;
 }
 
-.breadcrumb a:hover {
+  .breadcrumb a:hover {
+  color: var(--h1);
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary
- move breadcrumb below header and style using subdued text
- align scope icons before titles
- include redirect on logout URL
- correct `$page` variable to include `.php`

## Testing
- `composer --version` *(fails: command not found)*
- `php -l en/edit-app-core.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e73e08e0c8323b11d1695bb9d333b