### PR TITLE
Add app-connect translation strings

### DIFF
--- a/translations/app-connect-en.js
+++ b/translations/app-connect-en.js
@@ -5,9 +5,17 @@ TEXT TRANSLATION SNIPPETS FOR GOBRIK.com
 
 
 const en_Page_Translations = {
-
-
-
+    "001-first-time-to-connect": "Connect to",
+    "001-authorized-app": "is an authorized Buwana app",
+    "002-looks-like": "it looks like you are trying to login to",
+    "003-to-do-so": "To do so, we will connect your Buwana account to",
+    "004-buwana-profile": "Buwana Profile",
+    "005-data-essentials": "Essential user data for logging in and using the app...",
+    "004-will-be-granted": "Connect to authorize and get rocking on",
+    "009-connect-button": "Connect",
+    "1000-terms-of-use": "Terms of Use",
+    "010-no-connect": "↩ Or return to the",
+    "000-home": "home"
 };
 
 

--- a/translations/app-connect-fr.js
+++ b/translations/app-connect-fr.js
@@ -3,9 +3,16 @@ APP-CONNECT.PHP Translations
  */
 
 
-const en_Page_Translations = {
-
-
-
-
+const fr_Page_Translations = {
+    "001-first-time-to-connect": "Se connecter à",
+    "001-authorized-app": "est une application Buwana autorisée",
+    "002-looks-like": "il semble que vous essayiez de vous connecter à",
+    "003-to-do-so": "Pour ce faire, nous connecterons votre compte Buwana à",
+    "004-buwana-profile": "Profil Buwana",
+    "005-data-essentials": "Données utilisateur essentielles pour se connecter et utiliser l'application...",
+    "004-will-be-granted": "Connectez-vous pour autoriser et vous lancer sur",
+    "009-connect-button": "Se connecter",
+    "1000-terms-of-use": "Conditions d'utilisation",
+    "010-no-connect": "↩ Ou revenir à la",
+    "000-home": "page d'accueil"
 };


### PR DESCRIPTION
## Summary
- add English translation texts for `app-connect.php`
- translate those texts into French

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e8285e6708323af6db34ca30cb689