### PR TITLE
Add app-connect translation strings

### DIFF
--- a/en/app-connect.php
+++ b/en/app-connect.php
@@ -9,7 +9,7 @@ require_once '../fetch_app_info.php';
 // Page setup
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
 $page = 'app-connect';
-$version = '0.7771';
+$version = '0.7772';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
 error_reporting(E_ALL);
@@ -19,7 +19,7 @@ ini_set('display_errors', 1);
 // Page setup
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
 $page = 'app-connect';
-$version = '0.777';
+$version = '0.7772';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
 // --- Validate inputs

--- a/translations/app-connect-ar.js
+++ b/translations/app-connect-ar.js
@@ -4,8 +4,15 @@ APP-CONNECT.PHP Translations
 
 
 const ar_Page_Translations = {
-
-
-
-
+    "001-first-time-to-connect": "الاتصال بـ",
+    "001-authorized-app": "هو تطبيق بووانا معتمد",
+    "002-looks-like": "يبدو أنك تحاول تسجيل الدخول إلى",
+    "003-to-do-so": "للقيام بذلك، سنربط حسابك في بووانا بـ",
+    "004-buwana-profile": "ملف بووانا",
+    "005-data-essentials": "بيانات المستخدم الأساسية لتسجيل الدخول واستخدام التطبيق...",
+    "004-will-be-granted": "اتصل لتفويض وبدء العمل على",
+    "009-connect-button": "اتصال",
+    "1000-terms-of-use": "شروط الاستخدام",
+    "010-no-connect": "↩ أو العودة إلى",
+    "000-home": "الصفحة الرئيسية"
 };

--- a/translations/app-connect-de.js
+++ b/translations/app-connect-de.js
@@ -4,8 +4,15 @@ APP-CONNECT.PHP Translations
 
 
 const de_Page_Translations = {
-
-
-
-
+    "001-first-time-to-connect": "Verbinden mit",
+    "001-authorized-app": "ist eine autorisierte Buwana-App",
+    "002-looks-like": "es sieht so aus, als möchtest du dich anmelden bei",
+    "003-to-do-so": "Dazu verbinden wir dein Buwana-Konto mit",
+    "004-buwana-profile": "Buwana-Profil",
+    "005-data-essentials": "Wesentliche Nutzerdaten zum Anmelden und Nutzen der App...",
+    "004-will-be-granted": "Verbinde dich, um zu autorisieren und loszulegen auf",
+    "009-connect-button": "Verbinden",
+    "1000-terms-of-use": "Nutzungsbedingungen",
+    "010-no-connect": "↩ Oder zurück zur",
+    "000-home": "Startseite"
 };

--- a/translations/app-connect-en.js
+++ b/translations/app-connect-en.js
@@ -5,9 +5,17 @@ TEXT TRANSLATION SNIPPETS FOR GOBRIK.com
 
 
 const en_Page_Translations = {
-
-
-
+    "001-first-time-to-connect": "Connect to",
+    "001-authorized-app": "is an authorized Buwana app",
+    "002-looks-like": "it looks like you are trying to login to",
+    "003-to-do-so": "To do so, we will connect your Buwana account to",
+    "004-buwana-profile": "Buwana Profile",
+    "005-data-essentials": "Essential user data for logging in and using the app...",
+    "004-will-be-granted": "Connect to authorize and get rocking on",
+    "009-connect-button": "Connect",
+    "1000-terms-of-use": "Terms of Use",
+    "010-no-connect": "↩ Or return to the",
+    "000-home": "home"
 };
 
 

--- a/translations/app-connect-es.js
+++ b/translations/app-connect-es.js
@@ -4,8 +4,15 @@ APP-CONNECT.PHP Translations
 
 
 const es_Page_Translations = {
-
-
-
-
+    "001-first-time-to-connect": "Conectar a",
+    "001-authorized-app": "es una aplicación autorizada de Buwana",
+    "002-looks-like": "parece que estás intentando iniciar sesión en",
+    "003-to-do-so": "Para hacerlo, conectaremos tu cuenta de Buwana a",
+    "004-buwana-profile": "Perfil de Buwana",
+    "005-data-essentials": "Datos de usuario esenciales para iniciar sesión y usar la aplicación...",
+    "004-will-be-granted": "Conéctate para autorizar y comenzar en",
+    "009-connect-button": "Conectar",
+    "1000-terms-of-use": "Términos de uso",
+    "010-no-connect": "↩ O volver a",
+    "000-home": "inicio"
 };

--- a/translations/app-connect-fr.js
+++ b/translations/app-connect-fr.js
@@ -3,9 +3,16 @@ APP-CONNECT.PHP Translations
  */
 
 
-const en_Page_Translations = {
-
-
-
-
+const fr_Page_Translations = {
+    "001-first-time-to-connect": "Se connecter à",
+    "001-authorized-app": "est une application Buwana autorisée",
+    "002-looks-like": "il semble que vous essayiez de vous connecter à",
+    "003-to-do-so": "Pour ce faire, nous connecterons votre compte Buwana à",
+    "004-buwana-profile": "Profil Buwana",
+    "005-data-essentials": "Données utilisateur essentielles pour se connecter et utiliser l'application...",
+    "004-will-be-granted": "Connectez-vous pour autoriser et vous lancer sur",
+    "009-connect-button": "Se connecter",
+    "1000-terms-of-use": "Conditions d'utilisation",
+    "010-no-connect": "↩ Ou revenir à la",
+    "000-home": "page d'accueil"
 };

--- a/translations/app-connect-id.js
+++ b/translations/app-connect-id.js
@@ -4,8 +4,15 @@ APP-CONNECT.PHP Translations
 
 
 const id_Page_Translations = {
-
-
-
-
+    "001-first-time-to-connect": "Hubungkan ke",
+    "001-authorized-app": "adalah aplikasi Buwana resmi",
+    "002-looks-like": "sepertinya Anda mencoba masuk ke",
+    "003-to-do-so": "Untuk melakukannya, kami akan menghubungkan akun Buwana Anda ke",
+    "004-buwana-profile": "Profil Buwana",
+    "005-data-essentials": "Data pengguna penting untuk masuk dan menggunakan aplikasi...",
+    "004-will-be-granted": "Hubungkan untuk memberi izin dan mulai di",
+    "009-connect-button": "Hubungkan",
+    "1000-terms-of-use": "Syarat Penggunaan",
+    "010-no-connect": "↩ Atau kembali ke",
+    "000-home": "beranda"
 };

--- a/translations/app-connect-zh.js
+++ b/translations/app-connect-zh.js
@@ -4,8 +4,15 @@ APP-CONNECT.PHP Translations
 
 
 const zh_Page_Translations = {
-
-
-
-
+    "001-first-time-to-connect": "连接到",
+    "001-authorized-app": "是授权的 Buwana 应用",
+    "002-looks-like": "看起来你正在尝试登录到",
+    "003-to-do-so": "为此，我们将把你的 Buwana 账户连接到",
+    "004-buwana-profile": "Buwana 个人资料",
+    "005-data-essentials": "用于登录和使用应用的基本用户数据...",
+    "004-will-be-granted": "连接以授权并开始使用",
+    "009-connect-button": "连接",
+    "1000-terms-of-use": "使用条款",
+    "010-no-connect": "↩ 或返回",
+    "000-home": "首页"
 };


### PR DESCRIPTION
## Summary
- add English translation texts for `app-connect.php`
- translate those texts into French
- extend translations to Spanish, Indonesian, Arabic, German and Chinese
- bump `app-connect.php` version to 0.7772

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e8285e6708323af6db34ca30cb689