### PR TITLE
Add app About modal and menu item

### DIFF
--- a/header-2025.php
+++ b/header-2025.php
@@ -399,6 +399,13 @@ max-height: 200px;
 </div>
 
 <div class="menu-page-item">
+        <a href="javascript:void(0);" onclick="openAboutApp()">
+          About <?= htmlspecialchars($app_info['app_display_name']) ?>
+        </a>
+    <span class="status-circle" style="background-color: fuchsia;" title="About the app"></span>
+    </div>
+
+<div class="menu-page-item">
         <a href="javascript:void(0);" onclick="openAboutEarthen()" data-lang-id="1000-about-earthen">
           About Earthen
         </a>

--- a/scripts/app_modals.php
+++ b/scripts/app_modals.php
@@ -195,6 +195,20 @@ function openAboutBuwana() {
 }
 
 
+function openAboutApp() {
+  const appName = "<?= addslashes($app_info['app_display_name']) ?>";
+  const description = "<?= addslashes($app_info['app_description']) ?>";
+
+  const content = `
+        <div style="text-align:center; margin:auto; padding:10%;">
+            <h2>About ${appName}</h2>
+            <p>${description}</p>
+        </div>
+    `;
+  openModal(content);
+}
+
+
 function openAboutEarthen() {
     const content = `
         <div style="text-align:center; margin:auto; padding:10%;">


### PR DESCRIPTION
## Summary
- add `About App` menu item in `header-2025.php`
- implement `openAboutApp()` modal in `scripts/app_modals.php`

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d1dd7fd5083238cdf6dc4af482a92