### PR TITLE
Add login translations for zh, ar, de

### DIFF
--- a/translations/login-ar.js
+++ b/translations/login-ar.js
@@ -1,0 +1,22 @@
+/*-----------------------------------
+TEXT TRANSLATION SNIPPETS FOR GOBRIK.com
+-----------------------------------*/
+
+// Ampersand (&): Should be escaped as &amp; because it starts HTML character references.
+// Less-than (<): Should be escaped as &lt; because it starts an HTML tag.
+// Greater-than (>): Should be escaped as &gt; because it ends an HTML tag.
+// Double quote ("): Should be escaped as &quot; when inside attribute values.
+// Single quote/apostrophe ('): Should be escaped as &#39; or &apos; when inside attribute values.
+// Backslash (\\): Should be escaped as \\ in JavaScript strings to prevent ending the string prematurely.
+// Forward slash (/): Should be escaped as \/ in </script> tags to prevent prematurely closing a script.
+
+const ar_Page_Translations = {
+    "001-cant-find": "🤔 لا يمكننا العثور على بيانات الاعتماد هذه في قاعدة البيانات.",
+    "002-password-is-wrong": "👉 كلمة المرور خاطئة.",
+    "003-forgot-your-password": "هل نسيت كلمة المرور؟",
+    "000-reset-it": "أعد تعيينها.",
+    "003-code-status": "سيتم إرسال رمز لتسجيل الدخول إلى بريدك الإلكتروني.",
+    "004-login-button": '<input type="submit" id="submit-password-button" value="تسجيل الدخول" class="login-button-75">',
+    "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="كلمة مرورك...">'
+};
+

--- a/translations/login-de.js
+++ b/translations/login-de.js
@@ -1,0 +1,22 @@
+/*-----------------------------------
+TEXT TRANSLATION SNIPPETS FOR GOBRIK.com
+-----------------------------------*/
+
+// Ampersand (&): Should be escaped as &amp; because it starts HTML character references.
+// Less-than (<): Should be escaped as &lt; because it starts an HTML tag.
+// Greater-than (>): Should be escaped as &gt; because it ends an HTML tag.
+// Double quote ("): Should be escaped as &quot; when inside attribute values.
+// Single quote/apostrophe ('): Should be escaped as &#39; or &apos; when inside attribute values.
+// Backslash (\\): Should be escaped as \\ in JavaScript strings to prevent ending the string prematurely.
+// Forward slash (/): Should be escaped as \/ in </script> tags to prevent prematurely closing a script.
+
+const de_Page_Translations = {
+    "001-cant-find": "🤔 Wir können diese Zugangsdaten in der Datenbank nicht finden.",
+    "002-password-is-wrong": "👉 Passwort ist falsch.",
+    "003-forgot-your-password": "Passwort vergessen?",
+    "000-reset-it": "Setze es zurück.",
+    "003-code-status": "Ein Code zum Einloggen wird an deine E-Mail gesendet.",
+    "004-login-button": '<input type="submit" id="submit-password-button" value="Anmelden" class="login-button-75">',
+    "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="Dein Passwort...">'
+};
+

--- a/translations/login-zh.js
+++ b/translations/login-zh.js
@@ -1,0 +1,22 @@
+/*-----------------------------------
+TEXT TRANSLATION SNIPPETS FOR GOBRIK.com
+-----------------------------------*/
+
+// Ampersand (&): Should be escaped as &amp; because it starts HTML character references.
+// Less-than (<): Should be escaped as &lt; because it starts an HTML tag.
+// Greater-than (>): Should be escaped as &gt; because it ends an HTML tag.
+// Double quote ("): Should be escaped as &quot; when inside attribute values.
+// Single quote/apostrophe ('): Should be escaped as &#39; or &apos; when inside attribute values.
+// Backslash (\): Should be escaped as \\ in JavaScript strings to prevent ending the string prematurely.
+// Forward slash (/): Should be escaped as \/ in </script> tags to prevent prematurely closing a script.
+
+const zh_Page_Translations = {
+    "001-cant-find": "🤔 数据库中找不到此凭证。",
+    "002-password-is-wrong": "👉 密码错误。",
+    "003-forgot-your-password": "忘记密码了吗？",
+    "000-reset-it": "重设密码。",
+    "003-code-status": "登录代码将发送到你的电子邮件。",
+    "004-login-button": '<input type="submit" id="submit-password-button" value="登录" class="login-button-75">',
+    "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="你的密码...">'
+};
+


### PR DESCRIPTION
## Summary
- add login translations in Chinese
- add login translations in Arabic
- add login translations in German

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e6973222483239f54c25b971aa6f2