### PR TITLE
Move login status messages to translations

### DIFF
--- a/en/login.php
+++ b/en/login.php
@@ -96,6 +96,7 @@ echo 'const status = "' . addslashes($status) . '";';
 echo 'const firstName = "' . addslashes($first_name) . '";';
 echo 'const buwanaId = "' . addslashes($buwana_id) . '";';
 echo 'const code = "' . addslashes($code) . '";';
+echo 'const appDisplayName = "' . addslashes($app_info['app_display_name'] ?? '') . '";';
 echo '</script>';
 ?>
 
@@ -539,71 +540,24 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Function to get status messages
     function getStatusMessages(status, lang, firstName = '') {
-        const messages = {
-            logout: {
-                en: {
-                    main: "You're logged out.",
-                    sub: `When you're ready${firstName ? ' ' + firstName : ''}, login again with your account credentials.`
-                },
-                fr: {
-                    main: "Vous avez été déconnecté.",
-                    sub: `Quand vous êtes prêt${firstName ? ' ' + firstName : ''}, reconnectez-vous avec vos identifiants.`
-                },
-                id: {
-                    main: "Anda telah keluar.",
-                    sub: `Saat Anda siap${firstName ? ' ' + firstName : ''}, login lagi dengan kredensial akun Anda.`
-                },
-                es: {
-                    main: "Has cerrado tu sesión.",
-                    sub: `Cuando estés listo${firstName ? ' ' + firstName : ''}, vuelve a iniciar sesión con tus credenciales.`
-                }
-            },
-            firsttime: {
-                en: {
-                    main: "Your Buwana Account is Created! 🎉",
-                    sub: `And your Earthen subscriptions are confirmed.  Now${firstName ? ' ' + firstName : ''}, please login again with your new account credentials.`
-                },
-                fr: {
-                    main: "Votre compte Buwana est créé ! 🎉",
-                    sub: `Maintenant${firstName ? ' ' + firstName : ''}, connectez-vous avec vos nouvelles identifiants.`
-                },
-                id: {
-                    main: "Akun Buwana Anda sudah Dibuat! 🎉",
-                    sub: `Sekarang${firstName ? ' ' + firstName : ''}, silakan masuk dengan kredensial baru Anda.`
-                },
-                es: {
-                    main: "¡Tu cuenta de Buwana está creada! 🎉",
-                    sub: `Ahora${firstName ? ' ' + firstName : ''}, por favor inicia sesión con tus nuevas credenciales.`
-                }
-            },
-            default: {
-                en: {
-                    main: "Welcome back!",
-                    sub: `Please login again with your account credentials.`
-                },
-                fr: {
-                    main: "Bon retour !",
-                    sub: `Veuillez vous reconnecter avec vos identifiants.`
-                },
-                id: {
-                    main: "Selamat datang kembali!",
-                    sub: `Silakan masuk lagi dengan kredensial akun Anda.`
-                },
-                es: {
-                    main: "¡Bienvenido de nuevo!",
-                    sub: `Por favor inicia sesión de nuevo con tus credenciales.`
-                }
-            }
-        };
+        let messages;
+        switch (lang) {
+            case 'fr':
+                messages = typeof fr_LoginStatusMessages !== 'undefined' ? fr_LoginStatusMessages : en_LoginStatusMessages;
+                break;
+            default:
+                messages = en_LoginStatusMessages;
+        }
 
-        const selectedMessages = messages[status] && messages[status][lang]
-            ? messages[status][lang]
-            : messages.default[lang] || messages.default.en;
+        const selected = messages[status] || messages.default;
+        const main = selected.main
+            .replace('$app_display_name', appDisplayName)
+            .replace('$first_name', firstName);
+        const sub = selected.sub
+            .replace('$app_display_name', appDisplayName)
+            .replace('$first_name', firstName);
 
-        return {
-            main: selectedMessages.main,
-            sub: selectedMessages.sub
-        };
+        return { main, sub };
     }
 
     // Consolidated function to handle error responses and show the appropriate error div

--- a/translations/login-en.js
+++ b/translations/login-en.js
@@ -13,4 +13,27 @@ const en_Page_Translations = {
     "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="Your password...">',
 };
 
+/*-----------------------------------
+LOGIN STATUS MESSAGES
+----------------------------------*/
+
+const en_LoginStatusMessages = {
+    logout: {
+        main: "You're logged out.",
+        sub: "When you're ready $first_name, login again with your account credentials."
+    },
+    firsttime: {
+        main: "Your Buwana Account is Created! 🎉",
+        sub: "And your Earthen subscriptions are confirmed. Now $first_name, please login again with your new account credentials."
+    },
+    connected: {
+        main: "Your now set up to use $app_display_name",
+        sub: "$first_name, your Buwana account can now be used to login to $app_display_name"
+    },
+    default: {
+        main: "Welcome back!",
+        sub: "Please login again with your account credentials."
+    }
+};
+
 

--- a/translations/login-fr.js
+++ b/translations/login-fr.js
@@ -20,3 +20,26 @@ const fr_Page_Translations = {
     "004-login-button": '<input type="submit" id="submit-password-button" value="Connexion" class="login-button-75">',
     "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="Votre mot de passe...">'
 };
+
+/*-----------------------------------
+LOGIN STATUS MESSAGES
+----------------------------------*/
+
+const fr_LoginStatusMessages = {
+    logout: {
+        main: "Vous avez été déconnecté.",
+        sub: "Quand vous êtes prêt $first_name, reconnectez-vous avec vos identifiants."
+    },
+    firsttime: {
+        main: "Votre compte Buwana est créé ! 🎉",
+        sub: "Maintenant $first_name, connectez-vous avec vos nouvelles identifiants."
+    },
+    connected: {
+        main: "Vous êtes maintenant configuré pour utiliser $app_display_name",
+        sub: "$first_name, votre compte Buwana peut maintenant être utilisé pour se connecter à $app_display_name"
+    },
+    default: {
+        main: "Bon retour !",
+        sub: "Veuillez vous reconnecter avec vos identifiants."
+    }
+};


### PR DESCRIPTION
## Summary
- move login status strings out of `en/login.php`
- add new login status message "connected"
- provide English and French status translations
- reference new strings in `getStatusMessages`

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684e6de1b7808323ac191889f26847fc