### PR TITLE
Fix code login toggle and email matching

### DIFF
--- a/en/code_login_process.php
+++ b/en/code_login_process.php
@@ -33,7 +33,7 @@ if (!empty($_POST['code']) && !empty($_POST['credential_key'])) {
     }
 
     // PART 4: Validate Code
-    $stmt = $buwana_conn->prepare("SELECT buwana_id FROM credentials_tb WHERE credential_key = ? AND UPPER(2fa_temp_code) = ?");
+    $stmt = $buwana_conn->prepare("SELECT buwana_id FROM credentials_tb WHERE LOWER(credential_key) = ? AND UPPER(2fa_temp_code) = ?");
     if ($stmt) {
         $stmt->bind_param("ss", $credential_key, $code);
         if ($stmt->execute()) {

--- a/en/code_process.php
+++ b/en/code_process.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Exception\RequestException;
 
 // Initialize variables
 $response = array();
-$credential_key = $_POST['credential_key'] ?? '';
+$credential_key = strtolower(trim($_POST['credential_key'] ?? ''));
 $ecobricker_id = '';
 $buwana_activated = '';
 $first_name = '';
@@ -75,7 +75,7 @@ function sendVerificationCode($email_addr, $login_code, $buwana_id, $first_name)
 }
 
 // PART 3: Check GoBrik to see if the user account is activated
-$sql_check_email = "SELECT ecobricker_id, buwana_activated, email_addr, first_name FROM tb_ecobrickers WHERE email_addr = ?";
+$sql_check_email = "SELECT ecobricker_id, buwana_activated, email_addr, first_name FROM tb_ecobrickers WHERE LOWER(email_addr) = ?";
 $stmt_check_email = $gobrik_conn->prepare($sql_check_email);
 if ($stmt_check_email) {
     $stmt_check_email->bind_param('s', $credential_key);
@@ -109,7 +109,7 @@ if ($stmt_check_email) {
 }
 
 // PART 4: Check Buwana Database for the credential
-$sql_credential = "SELECT buwana_id, 2fa_issued_count FROM credentials_tb WHERE credential_key = ?";
+$sql_credential = "SELECT buwana_id, 2fa_issued_count FROM credentials_tb WHERE LOWER(credential_key) = ?";
 $stmt_credential = $buwana_conn->prepare($sql_credential);
 if ($stmt_credential) {
     $stmt_credential->bind_param('s', $credential_key);

--- a/en/login.php
+++ b/en/login.php
@@ -281,7 +281,7 @@ document.addEventListener('DOMContentLoaded', function () {
         fetch('code_login_process.php', {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: `code=${code}&credential_key=${credentialKeyInput.value}`
+            body: `code=${code}&credential_key=${credentialKeyInput.value.trim().toLowerCase()}`
         })
         .then(response => response.json())
         .then(data => handleAjaxResponse(data))
@@ -332,7 +332,7 @@ document.addEventListener('DOMContentLoaded', function () {
         fetch('code_process.php', {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: new URLSearchParams({ 'credential_key': credentialKeyInput.value })
+            body: new URLSearchParams({ 'credential_key': credentialKeyInput.value.trim().toLowerCase() })
         })
         .then(response => response.text())
         .then(text => {
@@ -482,14 +482,10 @@ document.addEventListener('DOMContentLoaded', function () {
     function updateButtonVisibility() {
         if (passwordToggle.checked) {
             sendCodeButton.style.display = 'none';
-            setTimeout(() => {
-                submitPasswordButton.style.display = 'block';
-            }, 600); // Delay for transition effect
+            submitPasswordButton.style.display = 'block';
         } else {
             submitPasswordButton.style.display = 'none';
-            setTimeout(() => {
-                sendCodeButton.style.display = 'block';
-            }, 600); // Delay for transition effect
+            sendCodeButton.style.display = 'block';
         }
     }
 
@@ -749,23 +745,17 @@ if (code && buwanaId) {
 
     // Function to update the visibility of the submit buttons
     function updateButtonVisibility() {
-     const passwordForm = document.getElementById('password-form');
-    const codeForm = document.getElementById('code-form');
-    const passwordToggle = document.getElementById('password');
-    const codeToggle = document.getElementById('code');
-    const submitPasswordButton = document.getElementById('submit-password-button');
-    const sendCodeButton = document.getElementById('send-code-button');
+        const passwordToggle = document.getElementById('password');
+        const codeToggle = document.getElementById('code');
+        const submitPasswordButton = document.getElementById('submit-password-button');
+        const sendCodeButton = document.getElementById('send-code-button');
 
         if (passwordToggle.checked) {
             sendCodeButton.style.display = 'none';
-            setTimeout(() => {
-                submitPasswordButton.style.display = 'block';
-            }, 600); // Delay for transition effect
+            submitPasswordButton.style.display = 'block';
         } else {
             submitPasswordButton.style.display = 'none';
-            setTimeout(() => {
-                sendCodeButton.style.display = 'block';
-            }, 600); // Delay for transition effect
+            sendCodeButton.style.display = 'block';
         }
     }
 

--- a/en/login_process.php
+++ b/en/login_process.php
@@ -5,7 +5,7 @@ require_once '../earthenAuth_helper.php'; // Include the authentication helper f
 startSecureSession();
 
 // PART 1: Grab user credentials from the login form submission
-$credential_key = $_POST['credential_key'] ?? '';
+$credential_key = strtolower(trim($_POST['credential_key'] ?? ''));
 $password = $_POST['password'] ?? '';
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
 $redirect = $_POST['redirect'] ?? ''; // Capture the redirect variable from POST
@@ -22,7 +22,7 @@ if (empty($credential_key) || empty($password)) {
 require_once("../gobrikconn_env.php");
 
 // Check the GoBrik database to see if the user has an unactivated account
-$sql_check_email = "SELECT ecobricker_id, buwana_activated FROM tb_ecobrickers WHERE email_addr = ?";
+$sql_check_email = "SELECT ecobricker_id, buwana_activated FROM tb_ecobrickers WHERE LOWER(email_addr) = ?";
 $stmt_check_email = $gobrik_conn->prepare($sql_check_email);
 
 if ($stmt_check_email) {
@@ -52,7 +52,7 @@ if ($stmt_check_email) {
 require_once("../buwanaconn_env.php");
 
 // SQL query to get buwana_id from credentials_tb using credential_key
-$sql_credential = "SELECT buwana_id FROM credentials_tb WHERE credential_key = ?";
+$sql_credential = "SELECT buwana_id FROM credentials_tb WHERE LOWER(credential_key) = ?";
 $stmt_credential = $buwana_conn->prepare($sql_credential);
 
 if ($stmt_credential) {
@@ -150,7 +150,7 @@ if ($stmt_credential) {
 
                 } else {
                     // PART 6: Handle failed login attempts
-                    $sql_check_failed = "SELECT failed_last_tm, failed_password_count FROM credentials_tb WHERE credential_key = ?";
+                    $sql_check_failed = "SELECT failed_last_tm, failed_password_count FROM credentials_tb WHERE LOWER(credential_key) = ?";
                     $stmt_check_failed = $buwana_conn->prepare($sql_check_failed);
 
                     if ($stmt_check_failed) {
@@ -175,7 +175,7 @@ if ($stmt_credential) {
                         $sql_update_failed = "UPDATE credentials_tb
                                               SET failed_last_tm = NOW(),
                                                   failed_password_count = ?
-                                              WHERE credential_key = ?";
+                                              WHERE LOWER(credential_key) = ?";
                         $stmt_update_failed = $buwana_conn->prepare($sql_update_failed);
 
                         if ($stmt_update_failed) {


### PR DESCRIPTION
## Summary
- handle credential keys in lowercase for login and code flow
- fix button visibility when toggling between login and send-code modes
- send trimmed lowercase credential to the server
- lookup emails case-insensitively when requesting login code

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684eac825f84832389a7c5a018d69af9