### PR TITLE
Fix login toggle styles

### DIFF
--- a/en/login.php
+++ b/en/login.php
@@ -177,8 +177,8 @@ echo '</script>';
 
     <div style="text-align:center;width:100%;margin:auto;margin-top:35px;max-width:500px;" id="login-buttons">
         <div class="toggle-container">
-            <input type="radio" id="password" name="toggle" value="password" checked>
-            <input type="radio" id="code" name="toggle" value="code">
+            <input type="radio" id="password-toggle" name="toggle" value="password" checked>
+            <input type="radio" id="code-toggle" name="toggle" value="code">
             <div class="toggle-button password">🔑</div>
             <div class="toggle-button code">📱</div>
             <div class="login-slider"></div>
@@ -445,8 +445,8 @@ document.addEventListener('DOMContentLoaded', function () {
 document.addEventListener('DOMContentLoaded', function () {
     const passwordForm = document.getElementById('password-form');
     const codeForm = document.getElementById('code-form');
-    const passwordToggle = document.getElementById('password');
-    const codeToggle = document.getElementById('code');
+    const passwordToggle = document.getElementById('password-toggle');
+    const codeToggle = document.getElementById('code-toggle');
     const submitPasswordButton = document.getElementById('submit-password-button');
     const sendCodeButton = document.getElementById('send-code-button');
 
@@ -664,7 +664,7 @@ if (code && buwanaId) {
     // Add a 0.3 sec pause
     setTimeout(() => {
         // Set the toggle to code
-        document.getElementById('code').checked = true;
+        document.getElementById('code-toggle').checked = true;
 
         // Run functions to update form and button visibility
         updateFormVisibility();
@@ -716,8 +716,8 @@ if (code && buwanaId) {
  function updateFormVisibility() {
   const passwordForm = document.getElementById('password-form');
     const codeForm = document.getElementById('code-form');
-    const passwordToggle = document.getElementById('password');
-    const codeToggle = document.getElementById('code');
+    const passwordToggle = document.getElementById('password-toggle');
+    const codeToggle = document.getElementById('code-toggle');
     const submitPasswordButton = document.getElementById('submit-password-button');
     const sendCodeButton = document.getElementById('send-code-button');
 
@@ -751,8 +751,8 @@ if (code && buwanaId) {
     function updateButtonVisibility() {
      const passwordForm = document.getElementById('password-form');
     const codeForm = document.getElementById('code-form');
-    const passwordToggle = document.getElementById('password');
-    const codeToggle = document.getElementById('code');
+    const passwordToggle = document.getElementById('password-toggle');
+    const codeToggle = document.getElementById('code-toggle');
     const submitPasswordButton = document.getElementById('submit-password-button');
     const sendCodeButton = document.getElementById('send-code-button');
 
@@ -773,8 +773,8 @@ if (code && buwanaId) {
     function updateFormAction() {
      const passwordForm = document.getElementById('password-form');
     const codeForm = document.getElementById('code-form');
-    const passwordToggle = document.getElementById('password');
-    const codeToggle = document.getElementById('code');
+    const passwordToggle = document.getElementById('password-toggle');
+    const codeToggle = document.getElementById('code-toggle');
     const submitPasswordButton = document.getElementById('submit-password-button');
     const sendCodeButton = document.getElementById('send-code-button');
 

--- a/includes/login-inc.php
+++ b/includes/login-inc.php
@@ -145,26 +145,26 @@
         }
 
 
-        #password:checked ~ .login-slider {
+        #password-toggle:checked ~ .login-slider {
             left: 0%;
         }
-        #code:checked ~ .login-slider {
+        #code-toggle:checked ~ .login-slider {
             left: 15% !important;
         }
 
-        #password:checked ~ .toggle-button.password {
+        #password-toggle:checked ~ .toggle-button.password {
             opacity: 1;
             width: 85%; /* Reduced width when selected */
         }
-        #password:checked ~ .toggle-button.code {
+        #password-toggle:checked ~ .toggle-button.code {
             opacity: 0.8;
             width: 15%; /* Expanded width when the other option is selected */
         }
-        #code:checked ~ .toggle-button.code {
+        #code-toggle:checked ~ .toggle-button.code {
             opacity: 1;
             width: 85%; /* Reduced width when selected */
         }
-        #code:checked ~ .toggle-button.password {
+        #code-toggle:checked ~ .toggle-button.password {
             opacity: 0.8;
             width: 15%; /* Expanded width when the other option is selected */
         }


### PR DESCRIPTION
## Summary
- avoid duplicate IDs by renaming radio buttons to `password-toggle` and `code-toggle`
- update JS selectors to use new IDs
- adjust style rules in `login-inc.php` to match updated IDs

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f12ffb1d8832394fd374df7d71772