### PR TITLE
Fix login action path

### DIFF
--- a/en/login-jwt.php
+++ b/en/login-jwt.php
@@ -804,7 +804,7 @@ if (code && buwanaId) {
         } else if (passwordToggle.checked) {
             // If the password option is selected
             passwordField.setAttribute('required', 'required');
-            form.action = '..processes/login_process-jwt.php';
+            form.action = '../processes/login_process_jwt.php';
             console.log("Password is checked.");
         }
     }


### PR DESCRIPTION
## Summary
- set correct path for password-based login JWT processing

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6850471e49ac83238931d17a88efa14c