### PR TITLE
Add client_id to JWT header

### DIFF
--- a/processes/login_process_jwt.php
+++ b/processes/login_process_jwt.php
@@ -111,7 +111,7 @@ if ($stmt_credential) {
                             }
                         }
 
-                        $jwt = JWT::encode($payload, $jwt_private_key, 'RS256');
+                        $jwt = JWT::encode($payload, $jwt_private_key, 'RS256', $client_id);
 
                         // One JWT per app session
                         $_SESSION['jwt'] = $jwt;


### PR DESCRIPTION
## Summary
- pass `$client_id` as kid when creating JWTs
- confirm `api/user_info.php` reads the `kid`

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68504906e01c832397b59c74a56e566c