### PR TITLE
Fix login redirect path

### DIFF
--- a/processes/login_process_jwt.php
+++ b/processes/login_process_jwt.php
@@ -125,7 +125,7 @@ if ($stmt_credential) {
                         $check_stmt->close();
 
                         if (!$connection_id) {
-                            header("Location: app-connect.php?id=$buwana_id&client_id=$client_id");
+                            header("Location: ../$lang/app-connect.php?id=$buwana_id&client_id=$client_id");
                             exit();
                         } else {
                             $_SESSION['connection_id'] = $connection_id;


### PR DESCRIPTION
## Summary
- prepend language directory when redirecting to app connection page in JWT login

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68504dae901c8323816595b1561f92bb