### PR TITLE
Implement CSRF validation in JWT login process

### DIFF
--- a/processes/login_process_jwt.php
+++ b/processes/login_process_jwt.php
@@ -14,6 +14,12 @@ $password = $_POST['password'] ?? '';
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
 $redirect = filter_var($_POST['redirect'] ?? '', FILTER_SANITIZE_SPECIAL_CHARS);
 $client_id = $_POST['client_id'] ?? ($_SESSION['client_id'] ?? null);
+$csrf_token = $_POST['csrf_token'] ?? '';
+
+if (!isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $csrf_token)) {
+    header("Location: ../$lang/login.php?status=invalid_csrf");
+    exit();
+}
 
 if (empty($credential_key) || empty($password)) {
     header("Location: ../$lang/login.php?status=empty_fields&key=" . urlencode($credential_key));


### PR DESCRIPTION
## Summary
- verify submitted `csrf_token` matches the session token in `login_process_jwt.php`
- redirect to login if the CSRF token validation fails

## Testing
- `composer install` *(fails: command not found)*
- `php -l processes/login_process_jwt.php` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68504fcaea0483239b4103176ab187ee