### PR TITLE
Fix community name query

### DIFF
--- a/processes/login_process_jwt.php
+++ b/processes/login_process_jwt.php
@@ -61,7 +61,7 @@ if ($stmt_credential) {
         $stmt_credential->fetch();
         $stmt_credential->close();
 
-        $sql_user = "SELECT password_hash, first_name, email, earthling_emoji, community_name, continent_code, open_id FROM users_tb WHERE buwana_id = ?";
+        $sql_user = "SELECT password_hash, first_name, email, earthling_emoji, community_id, continent_code, open_id FROM users_tb WHERE buwana_id = ?";
         $stmt_user = $buwana_conn->prepare($sql_user);
 
         if ($stmt_user) {
@@ -70,12 +70,14 @@ if ($stmt_credential) {
             $stmt_user->store_result();
 
             if ($stmt_user->num_rows === 1) {
-                $stmt_user->bind_result($password_hash, $first_name, $email, $earthling_emoji, $community_name, $continent_code, $open_id);
+                $stmt_user->bind_result($password_hash, $first_name, $email, $earthling_emoji, $community_id, $continent_code, $open_id);
                 $stmt_user->fetch();
 
                 if (password_verify($password, $password_hash)) {
                     $buwana_conn->query("UPDATE users_tb SET last_login = NOW(), login_count = login_count + 1 WHERE buwana_id = $buwana_id");
                     $buwana_conn->query("UPDATE credentials_tb SET last_login = NOW(), times_used = times_used + 1 WHERE buwana_id = $buwana_id");
+
+                    $community_name = getCommunityName($buwana_conn, $buwana_id);
 
                     $_SESSION['buwana_id'] = $buwana_id;
 


### PR DESCRIPTION
## Summary
- fix login_process_jwt to fetch community_id then look up community name

## Testing
- `phpunit --configuration phpunit.xml` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6850e0bd2b208323b27629b0ee5ac6da