### PR TITLE
Fix community lookup query

### DIFF
--- a/earthenAuth_helper.php
+++ b/earthenAuth_helper.php
@@ -128,7 +128,9 @@ function getCommunityName($buwana_conn, $buwana_id) {
 
             // Step 2: Use the retrieved community_id to get the com_name from communities_tb
             if (!empty($community_id)) {
-                $sql_community_name = "SELECT com_name FROM communities_tb WHERE com_id = ?";
+                // community_id is the primary key in communities_tb
+                // use it to retrieve the com_name
+                $sql_community_name = "SELECT com_name FROM communities_tb WHERE community_id = ?";
                 $stmt_community_name = $buwana_conn->prepare($sql_community_name);
 
                 if ($stmt_community_name) {


### PR DESCRIPTION
## Summary
- correct communities_tb primary key in `getCommunityName`

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850e395c59c8323882b64250d57bd05