### PR TITLE
Fix undefined variable in signup page

### DIFF
--- a/en/signup-3.php
+++ b/en/signup-3.php
@@ -50,6 +50,7 @@ $credential_key = '';
 $credential_type = '';
 $generated_code = '';
 $code_sent_flag = false;
+$code_sent = false; // Track whether an email has been sent in this request
 
 // 🔐 Generate activation code
 function generateCode() {


### PR DESCRIPTION
## Summary
- initialize `$code_sent` to avoid warnings

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6851531da9e88323946630c8371a0e01