### PR TITLE
Fix PHP warning with null coords

### DIFF
--- a/en/signup-4.php
+++ b/en/signup-4.php
@@ -141,8 +141,8 @@ if ($result_languages && $result_languages->num_rows > 0) {
                 </div>
 
                 <!-- Hidden Coordinates -->
-                <input type="hidden" id="lat" name="latitude" value="<?= htmlspecialchars($latitude) ?>">
-                <input type="hidden" id="lon" name="longitude" value="<?= htmlspecialchars($longitude) ?>">
+                <input type="hidden" id="lat" name="latitude" value="<?= htmlspecialchars((string)$latitude) ?>">
+                <input type="hidden" id="lon" name="longitude" value="<?= htmlspecialchars((string)$longitude) ?>">
 
                 <!-- MAP AND WATERSHED SEARCH SECTION -->
                 <div class="form-item" id="watershed-map-section" style="display: none; margin-top:20px;">


### PR DESCRIPTION
## Summary
- fix passing null to htmlspecialchars() in `signup-4.php`

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685157ea9a9483239af87a545e45e39a