### PR TITLE
Handle client_id during password resets

### DIFF
--- a/en/password-reset.php
+++ b/en/password-reset.php
@@ -3,7 +3,7 @@ require_once '../earthenAuth_helper.php'; // Include the authentication helper f
 
 // Set page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
-$version = '0.773';
+$version = '0.778';
 $page = 'reset';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
@@ -28,7 +28,18 @@ $first_name = '';  // Initialize the first_name variable
 
 
 include '../buwanaconn_env.php'; // This file provides the database server, user, dbname information to access the server
+
+// Determine client_id from ?app= or ?client_id=
+$client_id_param = $_GET['app'] ?? ($_GET['client_id'] ?? null);
+if ($client_id_param) {
+    $_SESSION['client_id'] = filter_var($client_id_param, FILTER_SANITIZE_SPECIAL_CHARS);
+}
+
 require_once '../fetch_app_info.php';         // Retrieves designated app's core data
+
+if (!empty($app_info['client_id'])) {
+    $_SESSION['client_id'] = $app_info['client_id'];
+}
 
 
 $token = isset($_GET['token']) ? trim($_GET['token']) : '';
@@ -55,17 +66,18 @@ if ($token) {
 echo '<!DOCTYPE html>
 <html lang="' . htmlspecialchars($lang, ENT_QUOTES, 'UTF-8') . '">
 <head>
-<meta charset="UTF-8">
-<title>Password Reset</title>
-';
+<meta charset="UTF-8">';
+echo '<title>Password Reset | ' . htmlspecialchars($app_info['app_display_name']) . '</title>';
 
 require_once ("../includes/reset-inc.php");
 
-echo '
-
-
-<!-- PAGE CONTENT -->
-<div id="top-page-image" class="credentials-banner top-page-image" style="margin-top: 65px;"></div>
+echo '\n\n<!-- PAGE CONTENT -->';
+$page_key = str_replace('-', '_', $page);
+echo '\n<div id="top-page-image"'
+    . ' class="top-page-image"'
+    . ' data-light-img="' . htmlspecialchars($app_info[$page_key . '_top_img_light'] ?? '') . '"'
+    . ' data-dark-img="' . htmlspecialchars($app_info[$page_key . '_top_img_dark'] ?? '') . '">'
+    . '</div>';
 
 <div id="form-submission-box" class="landing-page-form">
     <div class="form-container">
@@ -78,6 +90,7 @@ echo '
         <!-- Reset password form -->
         <form id="resetForm" method="post" action="../processes/process_reset.php">
             <input type="hidden" name="token" value="' . htmlspecialchars($token, ENT_QUOTES, 'UTF-8') . '">
+            <input type="hidden" name="client_id" value="' . htmlspecialchars($app_info['client_id']) . '">
             <div class="form-item">
                 <p data-lang-id="003-new-pass">New password:</p>
                 <div class="password-wrapper" data-lang-id="004-password-field">

--- a/processes/reset_pass.php
+++ b/processes/reset_pass.php
@@ -1,6 +1,12 @@
 <?php
 require '../vendor/autoload.php'; // Include Composer's autoloader
 require '../buwanaconn_env.php'; // Database connection information
+require '../earthenAuth_helper.php'; // For session management
+startSecureSession();
+
+// Determine client_id from POST or session
+$client_id = $_POST['client_id'] ?? ($_SESSION['client_id'] ?? '');
+$client_id = $client_id ? filter_var($client_id, FILTER_SANITIZE_SPECIAL_CHARS) : '';
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
@@ -52,7 +58,7 @@ if ($email) {
                 'en' => "Hello $first_name,<br><br>
                     A password reset was requested at " . date('Y-m-d H:i:s') . " on for your Buwana account. If you didn't request this, please disregard!<br><br>
                     To reset your password, please click the following link:<br><br>
-                    <a href='https://buwana.ecobricks.org/{$lang}/password-reset.php?token={$password_reset_token}'>Reset Password</a><br><br>
+                    <a href='https://buwana.ecobricks.org/{$lang}/password-reset.php?app={$client_id}&token={$password_reset_token}'>Reset Password</a><br><br>
                     The Buwana Team",
                 // Additional language bodies as above...
             ];


### PR DESCRIPTION
## Summary
- support client_id in password reset email links
- show the current app in `password-reset.php`

## Testing
- `phpunit --version` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6857904a4760832bb4213e2a83dc45f4