### PR TITLE
Fix password reset flow and add translations

### DIFF
--- a/en/password-reset.php
+++ b/en/password-reset.php
@@ -79,7 +79,7 @@ echo '\n<div id="top-page-image"'
     . ' data-dark-img="' . htmlspecialchars($app_info[$page_key . '_top_img_dark'] ?? '') . '">'
     . '</div>';
 
-<div id="form-submission-box" class="landing-page-form">
+echo '<div id="form-submission-box" class="landing-page-form">
     <div class="form-container">
 
         <div style="text-align:center;width:100%;margin:auto;">

--- a/js/login.js
+++ b/js/login.js
@@ -743,6 +743,24 @@ function showPasswordReset(type, lang = '<?php echo $lang; ?>', email = '') {
                     buttonText = "Atur Ulang Kata Sandi";
                     errorText = "🤔 Hmmm... kami tidak dapat menemukan akun yang menggunakan email ini!";
                     break;
+                case 'de':
+                    title = "Passwort zurücksetzen";
+                    promptText = "Geben Sie Ihre E-Mail ein, um Ihr Passwort zurückzusetzen:";
+                    buttonText = "Passwort zurücksetzen";
+                    errorText = "🤔 Hmmm... wir können kein Konto finden, das diese E-Mail verwendet!";
+                    break;
+                case 'ar':
+                    title = "إعادة تعيين كلمة المرور";
+                    promptText = "أدخل بريدك الإلكتروني لإعادة تعيين كلمة المرور:";
+                    buttonText = "إعادة تعيين كلمة المرور";
+                    errorText = "🤔 هممم... لا يمكننا العثور على حساب يستخدم هذا البريد الإلكتروني!";
+                    break;
+                case 'zh':
+                    title = "重置密码";
+                    promptText = "输入您的电子邮件以重置密码:";
+                    buttonText = "重置密码";
+                    errorText = "🤔 嗯...我们找不到使用该电子邮件的账户!";
+                    break;
                 default: // 'en'
                     title = "Reset Password";
                     promptText = "Enter your email to reset your password:";
@@ -764,6 +782,16 @@ function showPasswordReset(type, lang = '<?php echo $lang; ?>', email = '') {
                         <button type="submit" class="submit-button enabled" style="min-width: 350px;">${buttonText}</button>
                     </div>
                 </form>
+            `;
+            break;
+
+        case 'sent':
+            content = `
+                <div style="text-align:center;width:100%;margin:auto;margin-top:10px;margin-bottom:10px;">
+                    <h1>🙉</h1>
+                </div>
+                <div class="reset-title">Sent!</div>
+                <p>Your password reset has been sent to ${email}.  Please follow the link there to reset your Buwana password.</p>
             `;
             break;
 
@@ -794,6 +822,14 @@ window.onload = function() {
 
 
 //Relevant still?  Needs revision for status update of page variables.
+
+    // Check if the 'reset_sent_to' parameter exists in the URL
+    if (urlParams.has('reset_sent_to')) {
+        const email = urlParams.get('reset_sent_to') || '';
+
+        const lang = '<?php echo $lang; ?>';
+        showPasswordReset('sent', lang, email);
+    }
 
     // Check if the 'email_not_found' parameter exists in the URL
     if (urlParams.has('email_not_found')) {

--- a/processes/reset_pass.php
+++ b/processes/reset_pass.php
@@ -83,7 +83,8 @@ $mailgunDomain = getenv('MAILGUN_DOMAIN') ?: 'mail.gobrik.com';
                 if ($response->getStatusCode() == 200) {
                     $confirmation_code = uniqid("email_", true);
                     error_log("Mailgun: Email sent successfully to $email. Confirmation Code: " . $confirmation_code);
-                    echo '<script>alert("An email with a link to reset your Buwana password has been sent!"); window.location.href = "../' . $lang . '/login.php";</script>';
+                    header('Location: ../' . $lang . '/login.php?reset_sent_to=' . urlencode($email));
+                    exit();
                 } else {
                     error_log("Mailgun: Failed to send email to $email. Status: " . $response->getStatusCode());
                     echo '<script>alert("Failed to send email. Please try again later."); window.location.href = "../' . $lang . '/login.php";</script>';


### PR DESCRIPTION
## Summary
- support more languages in login password reset modal
- show a confirmation modal after sending password reset email
- redirect after reset without showing JS alert
- fix HTML echo in `password-reset.php`

## Testing
- `php -l en/password-reset.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685797a529c4832b92ba8411f1906926