### PR TITLE
Fix password reset redirect and toggle icons

### DIFF
--- a/en/password-reset.php
+++ b/en/password-reset.php
@@ -90,11 +90,12 @@ echo '<div id="form-submission-box" class="landing-page-form">
         <form id="resetForm" method="post" action="../processes/process_reset.php">
             <input type="hidden" name="token" value="' . htmlspecialchars($token, ENT_QUOTES, 'UTF-8') . '">
             <input type="hidden" name="client_id" value="' . htmlspecialchars($app_info['client_id']) . '">
+            <input type="hidden" name="lang" value="' . htmlspecialchars($lang, ENT_QUOTES, 'UTF-8') . '">
             <div class="form-item">
                 <p data-lang-id="003-new-pass">New password:</p>
-                <div class="password-wrapper" data-lang-id="004-password-field">
+                <div class="password-wrapper" data-lang-id="004-password-field" style="position: relative;">
                     <input type="password" id="password" name="password" required placeholder="Your new password...">
-                    <span toggle="#password" class="toggle-password" style="cursor: pointer;">🔒</span>
+                    <span toggle="#password" class="toggle-password" style="cursor: pointer; position: absolute; right: 10px; top: 50%; transform: translateY(-50%);font-size:18px;">🙈</span>
                 </div>
                 <p class="form-caption" data-lang-id="011-six-characters">Password must be at least 6 characters long.</p>
                 <div id="password-error" class="form-field-error" style="display:none;margin-top:0px;">👉 New password is not long enough!</div>
@@ -104,9 +105,9 @@ echo '<div id="form-submission-box" class="landing-page-form">
 
             <div class="form-item">
                 <p data-lang-id="012-re-enter">Re-enter password to confirm:</p>
-                <div data-lang-id="013-password-wrapper" class="password-wrapper">
+                <div data-lang-id="013-password-wrapper" class="password-wrapper" style="position: relative;">
                     <input type="password" id="confirmPassword" name="confirmPassword" required placeholder="Re-enter password...">
-                    <span toggle="#confirmPassword" class="toggle-password" style="cursor: pointer;">🔒</span>
+                    <span toggle="#confirmPassword" class="toggle-password" style="cursor: pointer; position: absolute; right: 10px; top: 50%; transform: translateY(-50%);font-size:18px;">🙈</span>
                 </div>
                 <div id="confirm-password-error" class="form-field-error" style="display:none;margin-top:5px;" data-lang-id="013-password-match">👉 Passwords do not match.</div>
             </div>
@@ -116,7 +117,7 @@ echo '<div id="form-submission-box" class="landing-page-form">
             </div>
         </form>
     </div>
-    <div style="text-align:center;width:100%;margin:auto;margin-top:34px;"><p style="font-size:medium;" data-lang-id="015-no-need">No need to reset your password?  <a href="login.php">Login</a></p></div>
+    <div style="text-align:center;width:100%;margin:auto;margin-top:34px;"><p style="font-size:medium;" data-lang-id="015-no-need">No need to reset your password?  <a href="login.php?app=' . urlencode($app_info['client_id']) . '">Login</a></p></div>
 </div>
 </div>';
 

--- a/js/core-2025.js
+++ b/js/core-2025.js
@@ -275,4 +275,23 @@ function updateChartTextColor() {
 document.addEventListener('DOMContentLoaded', updateChartTextColor);
 document.addEventListener('colorschemechange', updateChartTextColor);
 
+// Toggle password visibility on pages that include password fields
+document.addEventListener('DOMContentLoaded', function() {
+    const togglePasswordIcons = document.querySelectorAll('.toggle-password');
+    togglePasswordIcons.forEach(function(icon) {
+        icon.addEventListener('click', function() {
+            const input = document.querySelector(icon.getAttribute('toggle'));
+            if (input) {
+                if (input.type === 'password') {
+                    input.type = 'text';
+                    icon.textContent = '🙉';
+                } else {
+                    input.type = 'password';
+                    icon.textContent = '🙈';
+                }
+            }
+        });
+    });
+});
+
 

--- a/js/login.js
+++ b/js/login.js
@@ -1,34 +1,3 @@
-
-
-/* ---------- ------------------------------
-TOGGLE PASSWORD VISIBILITY
--------------------------------------------*/
-
-
-document.addEventListener("DOMContentLoaded", function() {
-    // Select all elements with the class 'toggle-password'
-    const togglePasswordIcons = document.querySelectorAll('.toggle-password');
-
-    togglePasswordIcons.forEach(function(icon) {
-        icon.addEventListener('click', function() {
-            // Find the associated input field using the 'toggle' attribute
-            const input = document.querySelector(icon.getAttribute('toggle'));
-            if (input) {
-                if (input.type === 'password') {
-                    input.type = 'text';
-                    icon.textContent = '🙉'; // 🔓 Change to unlocked emoji
-                } else {
-                    input.type = 'password';
-                    icon.textContent = '🙈'; // 🔒 Change to locked emoji
-                }
-            }
-        });
-    });
-});
-
-
-
-
 /*-----------------------------------------
 
 CODE PROCESSING

--- a/processes/process_reset.php
+++ b/processes/process_reset.php
@@ -6,8 +6,11 @@ ini_set('display_errors', 1);
 // Start the session before any output
 session_start();
 
-// Grab language directory from URL
-$lang = basename(dirname($_SERVER['SCRIPT_NAME']));
+// Determine language from form submission
+$lang = isset($_POST['lang']) ? preg_replace('/[^a-zA-Z]/', '', $_POST['lang']) : 'en';
+
+// Client ID for redirects
+$client_id = isset($_POST['client_id']) ? preg_replace('/[^a-zA-Z0-9_-]/', '', $_POST['client_id']) : '';
 
 // Database credentials
 include '../buwanaconn_env.php';
@@ -42,22 +45,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $stmt->execute();
                 $stmt->close();
 
-                echo '<script>alert("Your password has been reset! You can now log in using your new password."); window.location.href = "login.php";</script>';
+                echo '<script>alert("Your password has been reset! You can now log in using your new password."); window.location.href = "../' . $lang . '/login.php?app=' . urlencode($client_id) . '";</script>';
                 exit();
             } else {
-                echo '<script>alert("Invalid token. Please try reseting your password again."); window.location.href = "login.php";</script>';
+                echo '<script>alert("Invalid token. Please try reseting your password again."); window.location.href = "../' . $lang . '/login.php?app=' . urlencode($client_id) . '";</script>';
                 exit();
             }
         } else {
-            echo '<script>alert("Passwords do not match or are not long enough. Please try again."); window.location.href = "password-reset.php?token=' . urlencode($token) . '";</script>';
+            echo '<script>alert("Passwords do not match or are not long enough. Please try again."); window.location.href = "../' . $lang . '/password-reset.php?token=' . urlencode($token) . '";</script>';
             exit();
         }
     } else {
-        echo '<script>alert("All fields are required. Please try again."); window.location.href = "password-reset.php?token=' . urlencode($token) . '";</script>';
+        echo '<script>alert("All fields are required. Please try again."); window.location.href = "../' . $lang . '/password-reset.php?token=' . urlencode($token) . '";</script>';
         exit();
     }
 } else {
-    echo '<script>alert("Invalid request. Please try again reseting your password again."); window.location.href = "login.php";</script>';
+    echo '<script>alert("Invalid request. Please try again reseting your password again."); window.location.href = "../' . $lang . '/login.php?app=' . urlencode($client_id) . '";</script>';
     exit();
 }
 


### PR DESCRIPTION
## Summary
- adjust password reset form fields to include password view toggles
- send the language and client id to the reset handler
- update all reset redirects to include the language path and app client_id
- expose password toggle logic via core script
- remove duplicate password toggle code from `login.js`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6857b1148edc832bb63278c2e0cab2d5