### PR TITLE
Fix dataTable row colors for theme switching

### DIFF
--- a/styles/mode-dark.css
+++ b/styles/mode-dark.css
@@ -703,12 +703,14 @@ table.dataTable tbody tr:nth-child(odd),
 table.dataTable.stripe tbody tr.odd,
 table.dataTable.display tbody tr.odd {
   background-color: var(--table-background-1);
+  color: var(--text-color);
 }
 
 table.dataTable tbody tr:nth-child(even),
 table.dataTable.stripe tbody tr.even,
 table.dataTable.display tbody tr.even {
   background-color: var(--table-background-2);
+  color: var(--text-color);
 }
 
 table.dataTable tbody tr:hover {

--- a/styles/mode-light.css
+++ b/styles/mode-light.css
@@ -588,12 +588,14 @@ table.dataTable tbody tr:nth-child(odd),
 table.dataTable.stripe tbody tr.odd,
 table.dataTable.display tbody tr.odd {
     background-color: var(--table-background-1);
+    color: var(--text-color);
 }
 
 table.dataTable tbody tr:nth-child(even),
 table.dataTable.stripe tbody tr.even,
 table.dataTable.display tbody tr.even {
     background-color: var(--table-background-2);
+    color: var(--text-color);
 }
 
 table.dataTable tbody tr:hover {


### PR DESCRIPTION
## Summary
- adapt DataTables row background to theme variables
- ensure row text uses `var(--text-color)` in light and dark mode

## Testing
- `phpunit tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685834bf820c832ba13645d5b646b7d1