### PR TITLE
Handle missing client id on login

### DIFF
--- a/en/login.php
+++ b/en/login.php
@@ -27,9 +27,13 @@ if ($status === 'loggedout') {
 
 // --- Determine client_id from ?app= or ?client_id=
 $client_id_param = $_GET['app'] ?? ($_GET['client_id'] ?? null);
-if ($client_id_param) {
-    $_SESSION['client_id'] = filter_var($client_id_param, FILTER_SANITIZE_SPECIAL_CHARS);
+if (!$client_id_param) {
+    // No app specified so redirect back to the Buwana index
+    header('Location: index.php');
+    exit();
 }
+
+$_SESSION['client_id'] = filter_var($client_id_param, FILTER_SANITIZE_SPECIAL_CHARS);
 
 require_once '../fetch_app_info.php';         // Retrieves designated app's core data
 


### PR DESCRIPTION
## Summary
- redirect user to index if login page lacks a client_id parameter

## Testing
- `phpunit --version` *(fails: command not found)*
- `php -l en/login.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685900d36114832b9cc507456e85d631