### PR TITLE
Implement login lockout on repeated failures

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -430,7 +430,7 @@ document.addEventListener("DOMContentLoaded", function () {
         document.getElementById('no-buwana-email').style.display = 'none';
 
         // Show the appropriate error div based on the errorType
-        if (errorType === 'invalid_password') {
+        if (errorType === 'invalid_password' || errorType === 'too_many_attempts') {
             document.getElementById('password-error').style.display = 'block'; // Show password error
             shakeElement(document.getElementById('password-form'));
         } else if (errorType === 'invalid_user' || errorType === 'invalid_credential') {


### PR DESCRIPTION
## Summary
- prevent brute force by counting failed password checks
- store `failed_last_tm` and `failed_password_count`
- lock user out for 10 minutes after 5 failures
- show same password error in UI for lockout

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859fb3fcda8832ba52e7c3716b680ba