### PR TITLE
Add app details modal to index

### DIFF
--- a/en/index.php
+++ b/en/index.php
@@ -3,6 +3,9 @@ error_reporting(E_ALL);
 ini_set('display_errors', 1);
 session_start();
 
+// Hardcode the client ID for this page
+$_GET['app'] = 'buwana_mgr_001';
+
 require_once '../buwanaconn_env.php';
 require_once '../fetch_app_info.php';
 
@@ -14,7 +17,7 @@ $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 $buwana_id = isset($_GET['id']) && is_numeric($_GET['id']) ? intval($_GET['id']) : null;
 
 // 🔍 Fetch all apps
-$app_query = "SELECT client_id, app_display_name, app_login_url, app_slogan, app_square_icon_url FROM apps_tb ORDER BY app_display_name ASC";
+$app_query = "SELECT client_id, app_display_name, app_login_url, app_slogan, app_square_icon_url, app_description FROM apps_tb ORDER BY app_display_name ASC";
 $app_results = $buwana_conn->query($app_query);
 
 $apps = [];
@@ -58,14 +61,17 @@ if ($app_results && $app_results->num_rows > 0) {
           }
           $signup_link = "signup-1.php?app=$client_id";
       ?>
-        <div class="app-display-box">
+        <div class="app-display-box" data-description="<?= htmlspecialchars($app['app_description']) ?>">
           <img src="<?= htmlspecialchars($app['app_square_icon_url']) ?>" alt="<?= htmlspecialchars($app['app_display_name']) ?> Icon">
           <h4><?= htmlspecialchars($app['app_display_name']) ?></h4>
           <p class="app-slogan"><?= htmlspecialchars($app['app_slogan']) ?></p>
 
           <div class="app-actions">
-            <a href="<?= htmlspecialchars($login_link) ?>" class="simple-button">Login</a>
-            <a href="<?= htmlspecialchars($signup_link) ?>" class="simple-button">Signup</a>
+            <div class="button-row">
+              <a href="<?= htmlspecialchars($login_link) ?>" class="simple-button">Login</a>
+              <a href="<?= htmlspecialchars($signup_link) ?>" class="simple-button">Signup</a>
+            </div>
+            <a href="#" class="about-link" onclick="showAppDescription(event); return false;">ℹ️ About</a>
           </div>
         </div>
       <?php endforeach; ?>

--- a/includes/buwana-index-inc.php
+++ b/includes/buwana-index-inc.php
@@ -90,6 +90,8 @@
   justify-content: center;
   gap: 8px;
   margin-top: 45px;
+  flex-direction: column;
+  align-items: center;
 }
 
 .app-display-box:hover .app-actions,
@@ -111,6 +113,16 @@
   text-decoration: none;
 }
 
+.button-row {
+  display: flex;
+  gap: 8px;
+}
+
+.about-link {
+  font-size: 0.9em;
+  text-decoration: none;
+}
+
 .app-actions {
   position: absolute;
   top: 50%;
@@ -119,6 +131,8 @@
   display: flex;
   justify-content: center;
   gap: 8px;
+  flex-direction: column;
+  align-items: center;
   transform: translateY(-50%);
   opacity: 0;
   transition: opacity 0.3s ease;

--- a/js/core-2025.js
+++ b/js/core-2025.js
@@ -254,6 +254,22 @@ function openModal(contentHtml) {
     }
 }
 
+function showAppDescription(event) {
+    event.preventDefault();
+    const box = event.currentTarget.closest('.app-display-box');
+    if (!box) return;
+    const appName = box.querySelector('h4') ? box.querySelector('h4').textContent : '';
+    const description = box.dataset.description || '';
+
+    const content = `
+        <div style="text-align:center; margin:auto; padding:10%;">
+            <h2>About ${appName}</h2>
+            <p>${description}</p>
+        </div>
+    `;
+    openModal(content);
+}
+
 // Update Chart.js text color from the current theme
 function updateChartTextColor() {
     if (window.Chart && Chart.defaults) {


### PR DESCRIPTION
## Summary
- set client_id to buwana_mgr_001 on the index page
- show an "ℹ️ About" link for each app with login/signup
- display app descriptions via new `showAppDescription` JS
- tweak landing styles to support new link

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b65dea70c832bb17aaa59e13b341c