### PR TITLE
Fix signup redirection URL generation

### DIFF
--- a/en/signup-1.php
+++ b/en/signup-1.php
@@ -11,6 +11,11 @@ session_start(); // Needed for app context persistence
 require_once '../buwanaconn_env.php';         // Sets up $buwana_conn
 require_once '../fetch_app_info.php';         // Retrieves designated app's core data
 
+function build_login_url($base, array $params) {
+    $delimiter = (strpos($base, '?') !== false) ? '&' : '?';
+    return $base . $delimiter . http_build_query($params);
+}
+
 
 // Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
@@ -135,7 +140,8 @@ https://github.com/gea-ecobricks/buwana/-->
 
 
     <div style="font-size: medium; text-align: center; margin: auto; align-self: center;padding-top:40px;padding-bottom:50px;margin-top: 0px;">
-        <p style="font-size:medium;line-height:2em;"><span data-lang-id="000-already-have-account">Already have an account?</span> <br> <a href="<?= htmlspecialchars($app_info['app_login_url']) ?>/"><span data-lang-id="000-login-to"> Login to </span> <?= htmlspecialchars($app_info['app_display_name']) ?> ↗</a>.</p>
+        <?php $login_url = build_login_url($app_info['app_login_url'], ['app' => $app_info['client_id']]); ?>
+        <p style="font-size:medium;line-height:2em;"><span data-lang-id="000-already-have-account">Already have an account?</span> <br> <a href="<?= htmlspecialchars($login_url) ?>"><span data-lang-id="000-login-to"> Login to </span> <?= htmlspecialchars($app_info['app_display_name']) ?> ↗</a>.</p>
     </div>
 </div>
 

--- a/en/signup-2.php
+++ b/en/signup-2.php
@@ -6,6 +6,11 @@ session_start(); // Needed for app context persistence
 require_once '../buwanaconn_env.php';         // Sets up $buwana_conn
 require_once '../fetch_app_info.php';         // Retrieves designated app's core data
 
+function build_login_url($base, array $params) {
+    $delimiter = (strpos($base, '?') !== false) ? '&' : '?';
+    return $base . $delimiter . http_build_query($params);
+}
+
 
 // Set up page variables
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
@@ -68,9 +73,13 @@ if ($stmt_lookup_user) {
 // ✅ Check if signup is already completed
 if (!is_null($earthling_emoji) && trim($earthling_emoji) !== '') {
     // Redirect because signup is already done
+    $login_url = build_login_url($app_info['app_login_url'], [
+        'lang' => $lang,
+        'id'   => $buwana_id
+    ]);
     echo "<script>
         alert('Whoops! Looks like you’ve already completed your signup. No need to return to this page! Please login to your " . htmlspecialchars($app_info['app_display_name']) . " account.');
-        window.location.href = '" . htmlspecialchars($app_info['app_login_url']) . "?lang=" . urlencode($lang) . "&id=" . urlencode($buwana_id) . "';
+        window.location.href = '$login_url';
     </script>";
     exit();
 }
@@ -156,8 +165,9 @@ https://github.com/gea-ecobricks/buwana/-->
                      🚧 Whoops! Looks like that e-mail address is already being used by a Buwana Account. Please choose another.
                    </div>
                    <div id="duplicate-gobrik-email" class="form-warning">
-                     🌏 <span data-lang-id="006-gobrik-duplicate">It looks like this email is already being used with a legacy GoBrik account. Please <a href="login.php" class="underline-link">login with this email to upgrade your account.</a></span>
-                   </div>
+                     <?php $dup_login = build_login_url('login.php', ['app' => $app_info['client_id']]); ?>
+                     🌏 <span data-lang-id="006-gobrik-duplicate">It looks like this email is already being used with a legacy GoBrik account. Please <a href="<?= htmlspecialchars($dup_login) ?>" class="underline-link">login with this email to upgrade your account.</a></span>
+                  </div>
 
                    <div id="loading-spinner" class="spinner" style="display: none;margin-left: 10px;margin-top: 7px;"></div>
 

--- a/en/signup-3.php
+++ b/en/signup-3.php
@@ -5,6 +5,11 @@ session_start();
 
 require_once '../buwanaconn_env.php';
 require_once '../fetch_app_info.php';
+
+function build_login_url($base, array $params) {
+    $delimiter = (strpos($base, '?') !== false) ? '&' : '?';
+    return $base . $delimiter . http_build_query($params);
+}
 require '../vendor/autoload.php';
 
 use GuzzleHttp\Client;
@@ -37,9 +42,13 @@ if (!$buwana_id || !is_numeric($buwana_id)) {
 // ✅ Check if signup is already completed
 if (!is_null($earthling_emoji) && trim($earthling_emoji) !== '') {
     // Redirect because signup is already done
+    $login_url = build_login_url($app_info['app_login_url'], [
+        'lang' => $lang,
+        'id'   => $buwana_id
+    ]);
     echo "<script>
         alert('Whoops! Looks like you’ve already completed your signup. No need to return to this page! Please login to your " . htmlspecialchars($app_info['app_display_name']) . " account.');
-        window.location.href = '" . htmlspecialchars($app_info['app_login_url']) . "?lang=" . urlencode($lang) . "&id=" . urlencode($buwana_id) . "';
+        window.location.href = '$login_url';
     </script>";
     exit();
 }

--- a/en/signup-4.php
+++ b/en/signup-4.php
@@ -6,6 +6,11 @@ session_start();
 require_once '../buwanaconn_env.php';
 require_once '../fetch_app_info.php';
 
+function build_login_url($base, array $params) {
+    $delimiter = (strpos($base, '?') !== false) ? '&' : '?';
+    return $base . $delimiter . http_build_query($params);
+}
+
 // Page setup
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
 $page = 'signup-4';
@@ -50,9 +55,13 @@ if ($stmt) {
 // ✅ Check if signup is already completed
 if (!is_null($earthling_emoji) && trim($earthling_emoji) !== '') {
     // Redirect because signup is already done
+    $login_url = build_login_url($app_info['app_login_url'], [
+        'lang' => $lang,
+        'id'   => $buwana_id
+    ]);
     echo "<script>
         alert('Whoops! Looks like you’ve already completed your signup. No need to return to this page! Please login to your " . htmlspecialchars($app_info['app_display_name']) . " account.');
-        window.location.href = '" . htmlspecialchars($app_info['app_login_url']) . "?lang=" . urlencode($lang) . "&id=" . urlencode($buwana_id) . "';
+        window.location.href = '$login_url';
     </script>";
     exit();
 }

--- a/en/signup-6.php
+++ b/en/signup-6.php
@@ -6,6 +6,11 @@ session_start();
 require_once '../buwanaconn_env.php';
 require_once '../fetch_app_info.php';
 
+function build_login_url($base, array $params) {
+    $delimiter = (strpos($base, '?') !== false) ? '&' : '?';
+    return $base . $delimiter . http_build_query($params);
+}
+
 // Page setup
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
 $page = 'signup-6';
@@ -50,9 +55,13 @@ if ($stmt) {
 // ✅ Check if signup is already completed
 if (!is_null($earthling_emoji) && trim($earthling_emoji) !== '') {
     // Redirect because signup is already done
+    $login_url = build_login_url($app_info['app_login_url'], [
+        'lang' => $lang,
+        'id'   => $buwana_id
+    ]);
     echo "<script>
         alert('Whoops! Looks like you’ve already completed your signup. No need to return to this page! Please login to your " . htmlspecialchars($app_info['app_display_name']) . " account.');
-        window.location.href = '" . htmlspecialchars($app_info['app_login_url']) . "?lang=" . urlencode($lang) . "&id=" . urlencode($buwana_id) . "';
+        window.location.href = '$login_url';
     </script>";
     exit();
 }

--- a/en/signup-7.php
+++ b/en/signup-7.php
@@ -36,12 +36,18 @@ if ($stmt) {
 $app_display_name = $app_info['app_display_name'] ?? 'Your App';
 $app_login_url = $app_info['app_login_url'] ?? null;
 
+function build_login_url($base, array $params) {
+    $delimiter = (strpos($base, '?') !== false) ? '&' : '?';
+    return $base . $delimiter . http_build_query($params);
+}
+
 $redirect_url = $app_login_url
-    ? ($app_login_url .
-        '?lang=' . urlencode($lang) .
-        '&id=' . urlencode($buwana_id) .
-        '&status=firsttime' .
-        '&timezone=' . urlencode($time_zone))
+    ? build_login_url($app_login_url, [
+        'lang' => $lang,
+        'id' => $buwana_id,
+        'status' => 'firsttime',
+        'timezone' => $time_zone
+    ])
     : '/';
 
 ?>


### PR DESCRIPTION
## Summary
- fix query string handling in signup-7 redirect
- ensure repeated-signup redirects append query params properly
- update duplicate account login links with proper `app` parameter

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685e1f875210832b89ecf3bf402ec741