### PR TITLE
Fix redirect URL in signup-7

### DIFF
--- a/en/signup-7.php
+++ b/en/signup-7.php
@@ -46,7 +46,8 @@ $redirect_url = $app_login_url
         'lang' => $lang,
         'id' => $buwana_id,
         'status' => 'firsttime',
-        'timezone' => $time_zone
+        'timezone' => $time_zone,
+        'app' => $app_info['client_id'] ?? ''
     ])
     : '/';
 


### PR DESCRIPTION
## Summary
- ensure signup-7.php includes the client id when building the login redirect

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e228083c8832b96ba3467c97322ba