### PR TITLE
Fix reset password PHP warnings

### DIFF
--- a/en/reset_password-old.php
+++ b/en/reset_password-old.php
@@ -10,7 +10,7 @@ error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
 // Set language and validate the email input
-$lang = isset($_POST['lang']) ? filter_var($_POST['lang'], FILTER_SANITIZE_STRING) : 'en';
+$lang = isset($_POST['lang']) ? filter_var($_POST['lang'], FILTER_SANITIZE_SPECIAL_CHARS) : 'en';
 $email = isset($_POST['email']) ? filter_var(trim($_POST['email']), FILTER_VALIDATE_EMAIL) : '';
 
 if ($email) {

--- a/processes/reset_pass.php
+++ b/processes/reset_pass.php
@@ -16,7 +16,7 @@ error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
 // Set language and validate the email input
-$lang = isset($_POST['lang']) ? filter_var($_POST['lang'], FILTER_SANITIZE_STRING) : 'en';
+$lang = isset($_POST['lang']) ? filter_var($_POST['lang'], FILTER_SANITIZE_SPECIAL_CHARS) : 'en';
 $email = isset($_POST['email']) ? filter_var(trim($_POST['email']), FILTER_VALIDATE_EMAIL) : '';
 
 if ($email) {
@@ -28,6 +28,8 @@ if ($email) {
         }
         $stmt->bind_param("s", $email);
         $stmt->execute();
+        $result_email = null;
+        $first_name = '';
         $stmt->bind_result($result_email, $first_name);
         $stmt->fetch();
         $stmt->close();


### PR DESCRIPTION
## Summary
- fix deprecated filter constant usage
- initialise `$first_name` and `$result_email` to prevent warnings

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685fee7fae94832ba88c1237f908108c