### PR TITLE
Update login lockout messaging

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -431,7 +431,25 @@ document.addEventListener("DOMContentLoaded", function () {
 
         // Show the appropriate error div based on the errorType
         if (errorType === 'invalid_password' || errorType === 'too_many_attempts') {
-            document.getElementById('password-error').style.display = 'block'; // Show password error
+            const errorDiv = document.getElementById('password-error');
+
+            if (errorType === 'too_many_attempts') {
+                errorDiv.setAttribute('data-lang-id', '006-too-many-attempts');
+                if (window.translations && window.translations['006-too-many-attempts']) {
+                    errorDiv.textContent = window.translations['006-too-many-attempts'];
+                } else {
+                    errorDiv.textContent = '⚠️ Too many failed attempts. Try again in 10 minutes.';
+                }
+            } else {
+                errorDiv.setAttribute('data-lang-id', '002-password-is-wrong');
+                if (window.translations && window.translations['002-password-is-wrong']) {
+                    errorDiv.textContent = window.translations['002-password-is-wrong'];
+                } else {
+                    errorDiv.textContent = '👉 Password is wrong.';
+                }
+            }
+
+            errorDiv.style.display = 'block'; // Show password error
             shakeElement(document.getElementById('password-form'));
         } else if (errorType === 'invalid_user' || errorType === 'invalid_credential') {
 

--- a/translations/login-ar.js
+++ b/translations/login-ar.js
@@ -19,5 +19,6 @@ const ar_Page_Translations = {
     "003-code-status": "سيتم إرسال رمز لتسجيل الدخول إلى بريدك الإلكتروني.",
     "004-login-button": '<input type="submit" id="submit-password-button" value="تسجيل الدخول" class="login-button-75">',
     "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="كلمة مرورك...">'
+    "006-too-many-attempts": "⚠️ محاولات فاشلة كثيرة. حاول مرة أخرى خلال 10 دقائق."
 };
 

--- a/translations/login-de.js
+++ b/translations/login-de.js
@@ -19,5 +19,6 @@ const de_Page_Translations = {
     "003-code-status": "Ein Code zum Einloggen wird an deine E-Mail gesendet.",
     "004-login-button": '<input type="submit" id="submit-password-button" value="Anmelden" class="login-button-75">',
     "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="Dein Passwort...">'
+    "006-too-many-attempts": "⚠️ Zu viele Fehlversuche. Versuche es in 10 Minuten erneut."
 };
 

--- a/translations/login-en.js
+++ b/translations/login-en.js
@@ -14,6 +14,7 @@ const en_Page_Translations = {
     "003-code-status": "A code to login will be sent to your email.",
     "004-login-button": '<input type="submit" id="submit-password-button" value="Login" class="login-button-75">',
     "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="Your password...">',
+    "006-too-many-attempts": "⚠️ Too many failed attempts. Try again in 10 minutes."
 
 
 

--- a/translations/login-es.js
+++ b/translations/login-es.js
@@ -20,5 +20,6 @@ const es_Page_Translations = {
     "003-code-status": "Un código para iniciar sesión será enviado a tu correo electrónico.",
     "004-login-button": '<input type="submit" id="submit-password-button" value="Iniciar sesión" class="login-button-75">',
     "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="Tu contraseña...">'
+    "006-too-many-attempts": "⚠️ Demasiados intentos fallidos. Inténtalo de nuevo en 10 minutos."
 };
 

--- a/translations/login-fr.js
+++ b/translations/login-fr.js
@@ -19,5 +19,6 @@ const fr_Page_Translations = {
     "003-code-status": "Un code de connexion sera envoyé à votre adresse e-mail.",
     "004-login-button": '<input type="submit" id="submit-password-button" value="Connexion" class="login-button-75">',
     "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="Votre mot de passe...">',
+    "006-too-many-attempts": "⚠️ Trop de tentatives échouées. Réessayez dans 10 minutes."
 };
 

--- a/translations/login-id.js
+++ b/translations/login-id.js
@@ -19,4 +19,5 @@ const id_Page_Translations = {
     "003-code-status": "Kode untuk masuk akan dikirim ke email Anda.",
     "004-login-button": '<input type="submit" id="submit-password-button" value="Masuk" class="login-button-75">',
     "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="Kata sandi Anda...">'
+    "006-too-many-attempts": "⚠️ Terlalu banyak percobaan gagal. Coba lagi dalam 10 menit."
 };

--- a/translations/login-zh.js
+++ b/translations/login-zh.js
@@ -19,5 +19,6 @@ const zh_Page_Translations = {
     "003-code-status": "登录代码将发送到你的电子邮件。",
     "004-login-button": '<input type="submit" id="submit-password-button" value="登录" class="login-button-75">',
     "005-password-field-placeholder": '<input type="password" id="password" name="password" required placeholder="你的密码...">'
+    "006-too-many-attempts": "⚠️ 尝试失败次数过多。请在10分钟后再试。"
 };
 


### PR DESCRIPTION
## Summary
- add new too-many-attempts translation string for each language
- swap error text dynamically in login.js when lockout occurs

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e396311f8832bb9bc7d360622e207