### PR TITLE
Clean login logging and use global password toggle

### DIFF
--- a/en/login.php
+++ b/en/login.php
@@ -1,7 +1,5 @@
 <?php
 require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
 
 require_once '../buwanaconn_env.php';         // Sets up $buwana_conn
 
@@ -90,7 +88,6 @@ $code = isset($_GET['code']) ? filter_var($_GET['code'], FILTER_SANITIZE_SPECIAL
 $credential_key = ''; // Initialize $credential_key as empty
 $first_name = '';  // Initialize the first_name variable
 $redirect = isset($_GET['redirect']) ? filter_var($_GET['redirect'], FILTER_SANITIZE_SPECIAL_CHARS) : '';
-auth_log("Query parameters - status: $status, id: $buwana_id, redirect: $redirect");
 
 // Check if buwana_id is available and valid to fetch corresponding email and first_name from users_tb
 if (!empty($buwana_id)) {
@@ -112,7 +109,6 @@ if (!empty($buwana_id)) {
             if ($stmt->fetch()) {
                 $credential_key = $fetched_email;  // Store the fetched email
                 $first_name = $fetched_first_name;  // Store the fetched first_name
-                auth_log("Fetched user info for buwana_id $buwana_id");
             }
         }
 

--- a/js/login.js
+++ b/js/login.js
@@ -64,7 +64,6 @@ document.addEventListener('DOMContentLoaded', function () {
     function validateCode() {
         const fullCode = [...codeInputs].map(input => input.value.trim()).join('');
         if (fullCode.length === codeInputs.length) {
-            console.log("Code to validate: ", fullCode);
             ajaxValidateCode(fullCode);
         }
     }
@@ -77,8 +76,7 @@ document.addEventListener('DOMContentLoaded', function () {
             body: `code=${code}&credential_key=${credentialKeyInput.value}`
         })
             .then(response => response.json())
-            .then(data => handleAjaxResponse(data))
-            .catch(error => console.error('Error:', error));
+            .then(data => handleAjaxResponse(data));
     }
 
     // Function to handle AJAX response
@@ -339,12 +337,10 @@ document.addEventListener('DOMContentLoaded', function () {
             // If the code option is selected
             passwordField.removeAttribute('required');
             form.action = 'https://buwana.ecobricks.org/processes/code_process.php';
-            console.log("Code is checked.");
         } else if (passwordToggle.checked) {
             // If the password option is selected
             passwordField.setAttribute('required', 'required');
             form.action = 'https://buwana.ecobricks.org/processes/login_process_jwt.php';
-            console.log("Password is checked.");
         }
     }
 });
@@ -830,24 +826,6 @@ function showPasswordReset(type, lang = '<?php echo $lang; ?>', email = '') {
 
 
 
-// Toggle password visibility on pages that include password fields
-// Use event delegation so dynamic elements still respond
-document.addEventListener('click', function (e) {
-    if (e.target && e.target.classList.contains('toggle-password')) {
-        const icon = e.target;
-        const input = document.querySelector(icon.getAttribute('toggle'));
-        if (input) {
-            if (input.type === 'password') {
-                input.type = 'text';
-                icon.textContent = '🙉';
-            } else {
-                input.type = 'password';
-                icon.textContent = '🙈';
-            }
-        }
-    }
-});
-
 /* --------------------------------
 
 
@@ -885,7 +863,6 @@ window.onload = function() {
         setTimeout(() => {
             const noBuwanaEmail = document.getElementById('no-buwana-email');
             if (noBuwanaEmail) {
-                console.log("Displaying the 'email not found' error.");
                 noBuwanaEmail.style.display = 'block';
             }
         }, 100);

--- a/processes/login_process_jwt.php
+++ b/processes/login_process_jwt.php
@@ -36,7 +36,6 @@ if (!isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $cs
     exit();
 }
 
-auth_log("Credentials received for: $credential_key");
 
 if (empty($credential_key) || empty($password)) {
     auth_log('Empty credential key or password');
@@ -96,7 +95,6 @@ if ($stmt_credential) {
                 $stmt_user->fetch();
 
                 if (password_verify($password, $password_hash)) {
-                    auth_log("Password verified for buwana_id $buwana_id");
 
                     // Successful login, update login stats
                     $buwana_conn->query("UPDATE users_tb SET last_login = NOW(), login_count = login_count + 1 WHERE buwana_id = $buwana_id");
@@ -130,7 +128,6 @@ if ($stmt_credential) {
                         if (empty($open_id)) {
                             // If no OpenID exists for this user, you can either generate it here or throw error.
                             // For now, we error to be safe.
-                            auth_log("Missing open_id for buwana_id $buwana_id");
                             die("Internal error: open_id missing.");
                         }
 
@@ -148,7 +145,6 @@ if ($stmt_credential) {
                         try {
                             $jwt_token = JWT::encode($payload, $private_key, 'RS256', $client_id);
                             $_SESSION['jwt'] = $jwt_token;
-                            auth_log("JWT issued for buwana_id $buwana_id");
                         } catch (Exception $e) {
                             auth_log('JWT generation failed: ' . $e->getMessage());
                         }


### PR DESCRIPTION
## Summary
- stop showing PHP errors and avoid logging sensitive login data
- rely on `togglePasswordVisibility` from core-2025.js and drop old listener
- remove debug console output

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686ea396c31c832ba78785eccf917d87