### PR TITLE
Ensure user-app connection check on login redirect

### DIFF
--- a/en/login.php
+++ b/en/login.php
@@ -61,6 +61,9 @@ $is_logged_in = isLoggedIn(); // Check if the user is logged in using the helper
 
 // Check if user is logged in and session active
 if ($is_logged_in) {
+    require_once '../api/check_user_app_connection.php';
+    check_user_app_connection($buwana_conn, $_SESSION['buwana_id'], $_SESSION['client_id'], $lang);
+
     if (isset($_SESSION['pending_oauth_request'])) {
         // Redirect to authorize.php to continue the flow
         $params = http_build_query($_SESSION['pending_oauth_request']);


### PR DESCRIPTION
## Summary
- check for a registered user-app connection when visiting `en/login.php`

## Testing
- `php -l en/login.php`
- `php -l api/check_user_app_connection.php`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687641779b94832b80a78253ab117404