### PR TITLE
Fix redirect path in helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ vendor/bin/phpunit
 ```
 
 The configuration file `phpunit.xml` is provided in the repository.
+
+## Helper Functions
+
+`check_user_app_connection()` verifies that a logged-in user has an active
+connection to the requesting application. If no connection record exists the
+function now redirects using an absolute path (`/$lang/app-connect.php`) so that
+the redirect works even when called from nested scripts.

--- a/api/check_user_app_connection.php
+++ b/api/check_user_app_connection.php
@@ -19,7 +19,9 @@ function check_user_app_connection($buwana_conn, $buwana_id, $client_id, $lang =
         $check_stmt->close();
 
         if (!$connection_id) {
-            header("Location: ../$lang/app-connect.php?id=$buwana_id&client_id=$client_id");
+            // Use an absolute path so this redirect works no matter where the
+            // script was called from.
+            header("Location: /$lang/app-connect.php?id=$buwana_id&client_id=$client_id");
             exit();
         } else {
             $_SESSION['connection_id'] = $connection_id;


### PR DESCRIPTION
## Summary
- use absolute path for app-connect redirect
- document new redirect behavior

## Testing
- `php -l api/check_user_app_connection.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6876429c8f88832b94435ebdd2745967