### PR TITLE
Add user apps endpoint and profile display

### DIFF
--- a/api/get_user_app_connections.php
+++ b/api/get_user_app_connections.php
@@ -1,0 +1,52 @@
+<?php
+session_start();
+require_once __DIR__ . '/../buwanaconn_env.php';
+
+header('Content-Type: application/json');
+
+$allowed_origins = [
+    'https://earthcal.app',
+    'https://gobrik.com',
+    'https://ecobricks.org',
+    'https://learning.ecobricks.org',
+    'https://openbooks.ecobricks.org'
+];
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+if (in_array($origin, $allowed_origins)) {
+    header("Access-Control-Allow-Origin: $origin");
+    header('Access-Control-Allow-Credentials: true');
+    header('Access-Control-Allow-Methods: GET, OPTIONS');
+    header('Access-Control-Allow-Headers: Content-Type');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    exit(0);
+}
+
+$buwana_id = $_SESSION['buwana_id'] ?? null;
+
+if (!$buwana_id) {
+    echo json_encode(['logged_in' => false, 'apps' => []]);
+    exit();
+}
+
+$sql = "SELECT a.app_display_name, a.app_login_url, a.app_logo_url, a.app_logo_dark_url, a.app_version, a.app_slogan
+        FROM apps_tb a
+        JOIN user_app_connections_tb c ON a.client_id = c.client_id
+        WHERE c.buwana_id = ?";
+
+$apps = [];
+if ($stmt = $buwana_conn->prepare($sql)) {
+    $stmt->bind_param('i', $buwana_id);
+    if ($stmt->execute()) {
+        $result = $stmt->get_result();
+        if ($result) {
+            $apps = $result->fetch_all(MYSQLI_ASSOC);
+        }
+    }
+    $stmt->close();
+}
+
+echo json_encode(['logged_in' => true, 'apps' => $apps]);
+exit();
+?>

--- a/en/edit-profile.php
+++ b/en/edit-profile.php
@@ -482,6 +482,14 @@ echo '<!DOCTYPE html>
     </div>
 </div>
 
+<!-- CONNECTED APPS -->
+<div class="form-container" style="padding-top:20px;" id="connected-apps-container">
+    <h2>Your Apps</h2>
+    <p>You've connected to the following Buwana apps:</p>
+    <div id="connected-apps-row" class="connected-apps-row"></div>
+</div>
+
+
 
 
 <!-- DELETE ACCOUNT FORM -->
@@ -596,6 +604,45 @@ document.addEventListener('DOMContentLoaded', function () {
     if (status) {
         updateStatusMessage(status);
     }
+
+
+    // 🔗 Fetch connected apps and display logos
+    function updateConnectedAppLogos() {
+        const mode = document.documentElement.getAttribute('data-theme') || 'light';
+        document.querySelectorAll('.connected-app-logo').forEach(el => {
+            const lightLogo = el.getAttribute('data-light-logo');
+            const darkLogo = el.getAttribute('data-dark-logo');
+            el.style.backgroundImage = mode === 'dark' ? `url('${darkLogo}')` : `url('${lightLogo}')`;
+        });
+    }
+
+    fetch('../api/get_user_app_connections.php')
+        .then(resp => resp.json())
+        .then(data => {
+            if (data.logged_in && Array.isArray(data.apps)) {
+                const row = document.getElementById('connected-apps-row');
+                if (row) {
+                    row.innerHTML = '';
+                    data.apps.forEach(app => {
+                        const div = document.createElement('div');
+                        div.className = 'connected-app-logo';
+                        div.setAttribute('data-light-logo', app.app_logo_url);
+                        div.setAttribute('data-dark-logo', app.app_logo_dark_url);
+                        div.setAttribute('alt', app.app_display_name + ' App Logo');
+                        div.setAttribute('title', `${app.app_display_name} ${app.app_version} | ${app.app_slogan}`);
+                        row.appendChild(div);
+                    });
+                    updateConnectedAppLogos();
+                }
+            }
+        });
+
+    const toggle = document.getElementById('dark-mode-toggle-5');
+    if (toggle) {
+        toggle.addEventListener('colorschemechange', updateConnectedAppLogos);
+    }
+
+    updateConnectedAppLogos();
 
 });
 </script>

--- a/js/core-2025.js
+++ b/js/core-2025.js
@@ -194,7 +194,7 @@ document.addEventListener('DOMContentLoaded', () => {
         e.stopPropagation();
     });
 
-    fetch('/api/check_user_app_connections.php')
+    fetch('/api/get_user_app_connections.php')
         .then(resp => resp.json())
         .then(data => {
             if (data.logged_in && Array.isArray(data.apps)) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1931,3 +1931,20 @@ Sign up process
 .toggle-switch input:checked + .slider:before {
   transform: translateX(18px);
 }
+
+/* Connected apps list */
+.connected-apps-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.connected-app-logo {
+  max-width: 200px;
+  width: 100%;
+  height: 100px;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+}


### PR DESCRIPTION
## Summary
- implement `get_user_app_connections.php` to deliver a user's connected apps in JSON
- use new endpoint to show connected app logos in **edit-profile.php**
- fetch this endpoint in `core-2025.js`
- style connected app logos

## Testing
- `phpunit tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876724338cc832bad338dbf4f1ef9f8