### PR TITLE
Improve login selector height

### DIFF
--- a/header-2025.php
+++ b/header-2025.php
@@ -573,6 +573,7 @@ max-height: 200px;
         <?php endforeach; ?>
     <?php endif; ?>
   </div>
+  <button type="button" class="login-selector-close" id="login-selector-close" onclick="hideLoginSelector()" aria-label="Close login selector"></button>
 </div>
 
 

--- a/js/core-2025.js
+++ b/js/core-2025.js
@@ -148,7 +148,7 @@ document.addEventListener('DOMContentLoaded', () => {
             hideLoginSelector();
         } else {
             loginMenu.classList.add('menu-slider-visible');
-            loginMenu.style.maxHeight = '400px';
+            loginMenu.style.maxHeight = loginMenu.scrollHeight + 'px';
             loginMenu.style.overflow = 'hidden';
             loginMenu.style.transition = 'max-height 0.4s ease';
 
@@ -167,9 +167,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
     window.hideLoginSelector = () => {
         if (loginMenu.classList.contains('menu-slider-visible')) {
-            loginMenu.classList.remove('menu-slider-visible');
+            loginMenu.style.maxHeight = '0';
+            loginMenu.style.overflow = 'hidden';
+            loginMenu.style.transition = 'max-height 0.4s ease';
+
+            setTimeout(() => {
+                loginMenu.classList.remove('menu-slider-visible');
+                loginMenu.style.removeProperty('max-height');
+                loginMenu.style.removeProperty('overflow');
+                loginMenu.style.removeProperty('transition');
+                updateHeaderVisuals();
+            }, 400);
+
             document.removeEventListener('click', documentClickListenerLogin);
-            updateHeaderVisuals(); // ✅ Update visuals when hidden
         }
     };
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -787,7 +787,7 @@ border-color: #00a112 !important;
   #login-menu-slider {
     position: fixed;
     width: 100%;
-    height: 100px;
+    height: auto;
     top: -35px;
     background-color: var(--sub-menu);
     display: flex;
@@ -831,6 +831,21 @@ border-color: #00a112 !important;
  color: var(--text-color);
  text-decoration: underline;
 
+}
+
+/* Close button for login selector */
+.login-selector-close {
+  border: none;
+  width: 40px;
+  height: 30px;
+  margin: 10px auto 0;
+  background: url('../svgs/up-arrow.svg') no-repeat center;
+  background-size: contain;
+  cursor: pointer;
+}
+
+.login-selector-close:hover {
+  background-image: url('../svgs/up-arrow-over.svg');
 }
 
 


### PR DESCRIPTION
## Summary
- let login menu height adjust automatically
- add close arrow button to login selector
- animate showing/hiding of login menu

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6877391fc73c832bab740babb3c873e5