### PR TITLE
Fix dark-mode logo and signup defaults

### DIFF
--- a/en/signup-1.php
+++ b/en/signup-1.php
@@ -105,10 +105,10 @@ https://github.com/gea-ecobricks/buwana/-->
             name="credential"
             aria-label="Preferred Credential"
             required title="We'll send your account confirmation messages this way and you'll use this to login.">
-        <option value="" disabled selected data-lang-id="006-credential-choice">
+        <option value="" disabled data-lang-id="006-credential-choice">
             Select how you register...
         </option>
-        <option value="email">E-mail</option>
+        <option value="email" selected>E-mail</option>
         <option value="phone" disabled>Phone number</option>
         <option value="peer" disabled>Peer</option>
     </select>
@@ -254,6 +254,14 @@ document.addEventListener('DOMContentLoaded', () => {
     // ✅ Validation passed — manually dispatch a custom event that your global script expects
     const submitEvent = new Event('kickAssSubmit', { bubbles: true });
     form.dispatchEvent(submitEvent);
+  });
+
+  // 🔥 Trigger submit when user hits Enter
+  form.addEventListener('keydown', function(event) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      submitButton.click();
+    }
   });
 
 

--- a/footer-2025.php
+++ b/footer-2025.php
@@ -70,11 +70,19 @@
     try {
         var savedTheme = localStorage.getItem('dark-mode-toggle');
         const toggle = document.getElementById('dark-mode-toggle-5');
-const bannerElement = document.getElementById('top-page-image');
-        if (savedTheme && toggle) {
-            toggle.mode = savedTheme;
-            document.documentElement.setAttribute('data-theme', savedTheme);
+        const bannerElement = document.getElementById('top-page-image');
+
+        let initialMode = 'light';
+        if (savedTheme) {
+            initialMode = savedTheme;
+        } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            initialMode = 'dark';
         }
+
+        if (toggle) {
+            toggle.mode = initialMode;
+        }
+        document.documentElement.setAttribute('data-theme', initialMode);
 
         document.addEventListener('DOMContentLoaded', function() {
             const logoElement = document.querySelector('.the-app-logo');


### PR DESCRIPTION
## Summary
- default dark-mode to OS preference when no saved choice
- set email as selected credential for signup
- allow pressing Enter key to trigger signup form submission

## Testing
- `php -l footer-2025.php`
- `php -l en/signup-1.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68773e4899c0832bbbcb3365d1521e83