### PR TITLE
Propagate status parameter after login

### DIFF
--- a/en/login.php
+++ b/en/login.php
@@ -185,7 +185,8 @@ echo '</script>';
    <!-- Form starts here-->
 <form id="login" method="post" action="../processes/login_process_jwt.php">
     <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
-    <input type="hidden" name="redirect" value="<?php echo htmlspecialchars($redirect); ?>"> <!-- Add this line -->
+    <input type="hidden" name="redirect" value="<?php echo htmlspecialchars($redirect); ?>">
+    <input type="hidden" name="status" value="<?php echo htmlspecialchars($status); ?>">
     <input type="hidden" name="client_id" value="<?= htmlspecialchars($app_info['client_id']) ?>">
     <input type="hidden" name="response_type" value="id_token">
     <input type="hidden" name="scope" value="openid email profile">

--- a/processes/login_process_jwt.php
+++ b/processes/login_process_jwt.php
@@ -26,6 +26,7 @@ $password = $_POST['password'] ?? '';
 $lang = $_POST['lang'] ?? 'en';
 
 $redirect = filter_var($_POST['redirect'] ?? '', FILTER_SANITIZE_SPECIAL_CHARS);
+$status   = isset($_POST['status']) ? filter_var($_POST['status'], FILTER_SANITIZE_SPECIAL_CHARS) : '';
 $client_id = $_POST['client_id'] ?? ($_SESSION['client_id'] ?? null);
 $csrf_token = $_POST['csrf_token'] ?? '';
 
@@ -220,6 +221,10 @@ if ($stmt_credential) {
                         $redirect_url = $app_dashboard_url;
                     }
 
+                    if (!empty($status) && $status !== 'loggedout') {
+                        $delimiter = (strpos($redirect_url, '?') !== false) ? '&' : '?';
+                        $redirect_url .= $delimiter . 'status=' . urlencode($status);
+                    }
                     header("Location: $redirect_url");
                     exit();
                 } else {


### PR DESCRIPTION
## Summary
- forward `status` from login page
- append status query parameter when redirecting to the app dashboard

## Testing
- `php -l en/login.php`
- `php -l processes/login_process_jwt.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878745e5704832b9a53b00270655015