### PR TITLE
Fix redundant session_start

### DIFF
--- a/en/signup-1_process.php
+++ b/en/signup-1_process.php
@@ -1,7 +1,6 @@
 <?php
 require_once '../buwanaconn_env.php';
 require_once '../fetch_app_info.php';
-session_start();
 
 $success = false;
 


### PR DESCRIPTION
## Summary
- remove unused `session_start` from signup processing file

## Testing
- `php -l en/signup-1_process.php`


------
https://chatgpt.com/codex/tasks/task_e_687a72a35a74832b93e8d61daf246b43