### PR TITLE
Include app name in login titles

### DIFF
--- a/meta/login-ar.php
+++ b/meta/login-ar.php
@@ -1,4 +1,4 @@
-<title>تسجيل الدخول | بوانا</title>
+<title>تسجيل الدخول | <?= htmlspecialchars($app_info["app_display_name"]) ?> | بوانا</title>
 
 <meta name="keywords" content="تسجيل الدخول، بوانا، تطبيق بوانا، تطبيق تجديدي، مصادقة، تسجيل موحد، منظومة بوانا">
 <meta name="description" content="سجّل الدخول إلى تطبيقك التجديدي الرائع باستخدام بروتوكول المصادقة بوانانا">

--- a/meta/login-de.php
+++ b/meta/login-de.php
@@ -1,4 +1,4 @@
-<title>Anmelden | Buwana</title>
+<title>Anmelden | <?= htmlspecialchars($app_info["app_display_name"]) ?> | Buwana</title>
 
 <meta name="keywords" content="anmeldung, buwana, buwana app, regenerative app, authentifizierung, sso, buwana-ökosystem">
 <meta name="description" content="Melde dich bei deiner großartigen regenerativen App über das Buwanana-Authentifizierungsprotokoll an">

--- a/meta/login-en.php
+++ b/meta/login-en.php
@@ -1,4 +1,4 @@
-<title>Login | Buwana</title>
+<title>Login | <?= htmlspecialchars($app_info["app_display_name"]) ?> | Buwana</title>
 
 <meta name="keywords" content="login, buwana, buwana app, regenerative app, authentication, sso, buwana ecosystem">
 <meta name="description" content="Login to your awesome regenerative app using the Buwanana authentication protocol">

--- a/meta/login-es.php
+++ b/meta/login-es.php
@@ -1,4 +1,4 @@
-<title>Iniciar sesión | Buwana</title>
+<title>Iniciar sesión | <?= htmlspecialchars($app_info["app_display_name"]) ?> | Buwana</title>
 
 <meta name="keywords" content="inicio de sesión, buwana, aplicación buwana, aplicación regenerativa, autenticación, sso, ecosistema buwana">
 <meta name="description" content="Inicia sesión en tu increíble aplicación regenerativa usando el protocolo de autenticación Buwanana">

--- a/meta/login-fr.php
+++ b/meta/login-fr.php
@@ -1,4 +1,4 @@
-<title>Connexion | Buwana</title>
+<title>Connexion | <?= htmlspecialchars($app_info["app_display_name"]) ?> | Buwana</title>
 
 <meta name="keywords" content="connexion, buwana, application buwana, application régénératrice, authentification, sso, écosystème buwana">
 <meta name="description" content="Connectez-vous à votre application régénératrice géniale en utilisant le protocole d'authentification Buwanana">

--- a/meta/login-id.php
+++ b/meta/login-id.php
@@ -1,4 +1,4 @@
-<title>Masuk | Buwana</title>
+<title>Masuk | <?= htmlspecialchars($app_info["app_display_name"]) ?> | Buwana</title>
 
 <meta name="keywords" content="login, buwana, aplikasi buwana, aplikasi regeneratif, autentikasi, sso, ekosistem buwana">
 <meta name="description" content="Masuk ke aplikasi regeneratif Anda yang luar biasa menggunakan protokol autentikasi Buwanana">

--- a/meta/login-zh.php
+++ b/meta/login-zh.php
@@ -1,4 +1,4 @@
-<title>登录 | Buwana</title>
+<title>登录 | <?= htmlspecialchars($app_info["app_display_name"]) ?> | Buwana</title>
 
 <meta name="keywords" content="登录, Buwana, Buwana 应用, 再生应用, 认证, 单点登录, Buwana 生态">
 <meta name="description" content="使用 Buwanana 身份验证协议登录到您精彩的再生应用">


### PR DESCRIPTION
## Summary
- Dynamically insert the requesting app's display name in login page titles for all supported languages

## Testing
- `php -l meta/login-en.php`
- `php -l meta/login-es.php`
- `php -l meta/login-fr.php`
- `php -l meta/login-de.php`
- `php -l meta/login-id.php`
- `php -l meta/login-zh.php`
- `php -l meta/login-ar.php`
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa99805ed0832b946c3e9e42c07d0d