### PR TITLE
Move signup extras outside form container

### DIFF
--- a/en/signup-1.php
+++ b/en/signup-1.php
@@ -68,7 +68,7 @@ https://github.com/gea-ecobricks/buwana/-->
 
 <div class="login-panel-group">
     <div id="form-submission-box" class="landing-page-form">
-        <div class="form-container" style="box-shadow: #0000001f 0px 5px 20px;">
+        <div class="form-container">
             <div id="top-page-image"
                  class="top-page-image"
                  data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
@@ -115,23 +115,14 @@ https://github.com/gea-ecobricks/buwana/-->
 
 
   </form>
-
-            <div style="font-size: medium; text-align: center; margin: auto; align-self: center;padding-top:40px;padding-bottom:50px;margin-top: 0px;">
-                <?php $login_url = build_login_url($app_info['app_login_url'], ['app' => $app_info['client_id']]); ?>
-                <p style="font-size:medium;line-height:2em;"><span data-lang-id="000-already-have-account">Already have an account?</span> <br> <a href="<?= htmlspecialchars($login_url) ?>"><span data-lang-id="000-login-to"> Login to </span> <?= htmlspecialchars($app_info['app_display_name']) ?> ↗</a>.</p>
-            </div>
         </div>
     </div>
+    <div style="font-size: medium; text-align: center; margin: auto; align-self: center;padding-top:40px;padding-bottom:50px;margin-top: 0px;">
+        <?php $login_url = build_login_url($app_info['app_login_url'], ['app' => $app_info['client_id']]); ?>
+        <p style="font-size:medium;line-height:2em;"><span data-lang-id="000-already-have-account">Already have an account?</span> <br> <a href="<?= htmlspecialchars($login_url) ?>"><span data-lang-id="000-login-to"> Login to </span> <?= htmlspecialchars($app_info['app_display_name']) ?> ↗</a>.</p>
+    </div>
 </div>
-
-
       </div><!--closes Landing content-->
-
-
-
-
-
-
  </div>
 
 </div><!--closes main and starry background-->

--- a/en/signup-2.php
+++ b/en/signup-2.php
@@ -121,20 +121,18 @@ https://github.com/gea-ecobricks/buwana/-->
     <div id="splash-bar"></div>-->
 
 <!-- PAGE CONTENT -->
-
-<!-- PAGE CONTENT -->
    <?php
    $page_key = str_replace('-', '_', $page); // e.g. 'signup-1' → 'signup_1'
    ?>
 
-   <div id="top-page-image"
-        class="top-page-image"
-        data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
-        data-dark-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_dark']) ?>">
-   </div>
-
-<div id="form-submission-box" class="landing-page-form" >
-    <div class="form-container">
+<div class="login-panel-group">
+    <div id="form-submission-box" class="landing-page-form" >
+        <div class="form-container">
+            <div id="top-page-image"
+                class="top-page-image"
+                data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
+                data-dark-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_dark']) ?>">
+            </div>
 
             <div style="text-align:center;width:100%;margin:auto;">
                 <h2><span data-lang-id="001-register-by"></span> <?php echo $credential_type; ?></h2>
@@ -227,19 +225,15 @@ https://github.com/gea-ecobricks/buwana/-->
              </div>
 
 
-           </form>
+            </form>
+        </div>
+    </div>
+    <div id="browser-back-link" style="font-size: medium; text-align: center; margin: auto; align-self: center; padding-top: 40px; padding-bottom: 40px; margin-top: 0px;" >
+        <p style="font-size: medium;">
 
-</div>
-
-
-<div id="browser-back-link" style="font-size: medium; text-align: center; margin: auto; align-self: center; padding-top: 40px; padding-bottom: 40px; margin-top: 0px;" >
-    <p style="font-size: medium;">
-
-        <a href="#" onclick="browserBack(event)" data-lang-id="000-go-back">↩ Go back a step</a>
-    </p>
-</div>
-
-
+            <a href="#" onclick="browserBack(event)" data-lang-id="000-go-back">↩ Go back a step</a>
+        </p>
+    </div>
 
     </div>
 </div>  <!--main closes-->

--- a/includes/signup-1-inc.php
+++ b/includes/signup-1-inc.php
@@ -3,6 +3,16 @@
 <?php require_once ("../meta/$page-$lang.php");?>
 
 <style>
+#main {
+    height: fit-content;
+}
+
+.form-container {
+    max-width: 800px;
+    margin: 0 auto;
+    box-shadow: #0000001f 0px 5px 20px;
+}
+
 /*     @media (prefers-color-scheme: light) { */
 /*         .app-signup-banner { */
 /*             background: url('<?= htmlspecialchars($app_info['signup_top_img_url']) ?>?v=2') no-repeat center; */

--- a/includes/signup-2-inc.php
+++ b/includes/signup-2-inc.php
@@ -4,6 +4,16 @@
 
 <STYLE>
 
+#main {
+    height: fit-content;
+}
+
+.form-container {
+    max-width: 800px;
+    margin: 0 auto;
+    box-shadow: #0000001f 0px 5px 20px;
+}
+
 .bullet-container {
   position: relative;
   padding-left: 28px; /* Leave space for the bullet */


### PR DESCRIPTION
## Summary
- Place "Already have an account" link below the signup form container
- Wrap signup step 2 in login-panel-group and add back link below form
- Center signup steps on large screens via shared form-container styles

## Testing
- `php -l includes/signup-1-inc.php`
- `php -l includes/signup-2-inc.php`
- `php -l en/signup-1.php`
- `php -l en/signup-2.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aac11439b0832b819a50bda59c03e7