### PR TITLE
Align signup-3 page structure with signup-2

### DIFF
--- a/en/signup-3.php
+++ b/en/signup-3.php
@@ -197,17 +197,17 @@ https://github.com/gea-ecobricks/buwana/-->
 
 <!-- PAGE CONTENT -->
    <?php
-   $page_key = str_replace('-', '_', $page); // e.g. 'signup-1' → 'signup_1'
-   ?>
+    $page_key = str_replace('-', '_', $page); // e.g. 'signup-1' → 'signup_1'
+    ?>
 
-   <div id="top-page-image"
-        class="top-page-image"
-        data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
-        data-dark-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_dark']) ?>">
-   </div>
-
-<div id="form-submission-box" class="landing-page-form">
-    <div class="form-container">
+<div class="page-panel-group">
+    <div id="form-submission-box" class="landing-page-form" style="min-height:calc( 100vh - 54px)">
+        <div class="form-container">
+            <div id="top-page-image"
+                class="top-page-image"
+                data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
+                data-dark-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_dark']) ?>">
+            </div>
 
        <!-- Email confirmation form -->
 <div id="first-send-form" style="text-align:center;width:100%;margin:auto;margin-top:10px;margin-bottom:10px;"
@@ -257,27 +257,20 @@ https://github.com/gea-ecobricks/buwana/-->
     <p id="resend-code" style="font-size:1em"><span data-lang-id="009-no-code">Didn't get your code? You can request a resend of the code in</span> <span id="timer">1:00</span></p>
 </div>
 
-
 </div>
-
-
+        </div>
+        <?php if (!empty($buwana_id)) : ?>
+        <div id="browser-back-link" style="font-size: medium; text-align: center; margin: auto; align-self: center; padding-top: 40px; padding-bottom: 40px; margin-top: 0px; ">
+            <p style="font-size:1em;line-height: 1.9em;"><span data-lang-id="011-change-email">Need to change your email? </span><br><a href="#" onclick="browserBack(event)" data-lang-id="000-go-back">↩ Go back</a>
+            </p>
+        </div>
+        <?php else : ?>
+        <div id="legacy-account-email-not-used" style="text-align:center;width:90%;margin:auto;margin-top:30px;margin-bottom:50px;">
+            <p style="font-size:1em;line-height: 1.9em;" data-lang-id="010-email-no-longer">Do you no longer use this email address?<br>If not, you'll need to <a href="signup-1.php">create a new account</a> or contact our team at support@gobrik.com.</p>
+        </div>
+        <?php endif; ?>
+    </div>
 </div>
-
-<?php if (!empty($buwana_id)) : ?>
-<div id="browser-back-link" style="font-size: medium; text-align: center; margin: auto; align-self: center; padding-top: 40px; padding-bottom: 40px; margin-top: 0px; ">
-    <p style="font-size:1em;line-height: 1.9em;"><span data-lang-id="011-change-email">Need to change your email? </span><br><a href="#" onclick="browserBack(event)" data-lang-id="000-go-back">↩ Go back</a>
-    </p>
-<?php else : ?>
-<div id="legacy-account-email-not-used" style="text-align:center;width:90%;margin:auto;margin-top:30px;margin-bottom:50px;">
-    <p style="font-size:1em;line-height: 1.9em;" data-lang-id="010-email-no-longer">Do you no longer use this email address?<br>If not, you'll need to <a href="signup-1.php">create a new account</a> or contact our team at support@gobrik.com.</p>
-</div>
-<?php endif; ?>
-</div>
-
-
-</div>
-
-
 
 </div> <!--Closes main-->
 

--- a/en/signup-4.php
+++ b/en/signup-4.php
@@ -113,16 +113,15 @@ if ($result_languages && $result_languages->num_rows > 0) {
    <?php
    $page_key = str_replace('-', '_', $page); // e.g. 'signup-1' → 'signup_1'
    ?>
-
-   <div id="top-page-image"
-        class="top-page-image"
-        data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
-        data-dark-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_dark']) ?>">
-   </div>
-
-
-    <div id="form-submission-box" class="landing-page-form">
+<div class="page-panel-group">
+    <div id="form-submission-box" class="landing-page-form" style="min-height:calc( 100vh - 54px)">
         <div class="form-container" style="box-shadow: #0000001f 0px 5px 20px;">
+
+            <div id="top-page-image"
+                 class="top-page-image"
+                 data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
+                 data-dark-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_dark']) ?>">
+            </div>
 
             <div style="text-align:center;width:100%;margin:auto;">
                 <p style="color:green;" data-lang-id="001-email-confirmed">✔ Your email is confirmed!</p>
@@ -191,7 +190,6 @@ if ($result_languages && $result_languages->num_rows > 0) {
             </p>
         </div>
     </div>
-
 </div>
 
 

--- a/en/signup-5.php
+++ b/en/signup-5.php
@@ -135,15 +135,16 @@ if (!empty($credential_key)) {
    $page_key = str_replace('-', '_', $page); // e.g. 'signup-1' → 'signup_1'
    ?>
 
-   <div id="top-page-image"
-        class="top-page-image"
-        data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
-        data-dark-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_dark']) ?>">
-   </div>
+<div class="page-panel-group">
+    <div id="form-submission-box" class="landing-page-form" style="min-height:calc( 100vh - 54px)">
+        <div class="form-container">
 
+            <div id="top-page-image"
+                 class="top-page-image"
+                 data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
+                 data-dark-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_dark']) ?>">
+            </div>
 
-<div id="form-submission-box" class="landing-page-form">
-    <div class="form-container">
         <div style="text-align:center;width:100%;margin:auto;">
             <h2 data-lang-id="001-select-subs"></h2>
             <h4 style="color:#748931;" data-lang-id="002-sub-subtitle"></h4>
@@ -184,16 +185,12 @@ if (!empty($credential_key)) {
             </form>
         </div>
     </div>
+
+    <div id="browser-back-link" style="font-size: medium; text-align: center; margin: auto; align-self: center; padding-top: 40px; padding-bottom: 40px; margin-top: 0px;">
+        <p style="font-size: 1em"><a href="#" onclick="browserBack(event)" data-lang-id="000-go-back">↩ Go back one</a></p>
+    </div>
+    </div>
 </div>
-
-
-
-<div id="browser-back-link" style="font-size: medium; text-align: center; margin: auto; align-self: center; padding-top: 40px; padding-bottom: 40px; margin-top: 0px;">
-    <p style="font-size: 1em"><a href="#" onclick="browserBack(event)" data-lang-id="000-go-back">↩ Go back one</a></p>
-</div>
-
-
-</div> <!--CLoses main-->
 
 <!-- FOOTER STARTS HERE -->
 <?php require_once ("../footer-2025.php"); ?>

--- a/en/signup-6.php
+++ b/en/signup-6.php
@@ -119,14 +119,16 @@ https://github.com/gea-ecobricks/gobrik-3.0/tree/main/en-->
    $page_key = str_replace('-', '_', $page); // e.g. 'signup-1' → 'signup_1'
    ?>
 
-   <div id="top-page-image"
-        class="top-page-image"
-        data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
-        data-dark-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_dark']) ?>">
-   </div>
-
-<div id="form-submission-box" class="landing-page-form">
+<div class="page-panel-group">
+<div id="form-submission-box" class="landing-page-form" style="min-height:calc( 100vh - 54px)">
     <div class="form-container">
+
+        <div id="top-page-image"
+             class="top-page-image"
+             data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
+             data-dark-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_dark']) ?>">
+        </div>
+
         <div style="text-align:center;width:100%;margin:auto;">
             <p style="color:green;" data-lang-id="001-subs-set">✔ Your Earthen subscriptions are confirmed!</p>
             <div id="status-message"><h4 data-lang-id="002-fun-part" style="margin-bottom: 12px;margin-top:0px;">Now the fun part!</h4></div>
@@ -316,20 +318,14 @@ $current_lang_dir = basename(dirname($_SERVER['SCRIPT_NAME']));
 
 </form>
 
-
-
-
-
     </div>
 
-
-<div id="browser-back-link" style="font-size: medium; text-align: center; margin: auto; align-self: center; padding-top: 40px; padding-bottom: 40px; margin-top: 0px;">
+    <div id="browser-back-link" style="font-size: medium; text-align: center; margin: auto; align-self: center; padding-top: 40px; padding-bottom: 40px; margin-top: 0px;">
             <p style="font-size: medium;">
                 <a href="#" onclick="browserBack(event)" data-lang-id="000-go-back">↩ Go back one step</a>
             </p>
         </div>
     </div>
-
 </div>
 <!-- FOOTER STARTS HERE -->
 <?php require_once ("../footer-2025.php"); ?>

--- a/en/signup-7.php
+++ b/en/signup-7.php
@@ -60,34 +60,33 @@ $redirect_url = $app_login_url
   <meta charset="UTF-8">
 
 
-  <?php require_once ("../includes/signup-7-inc.php");?>
+<?php require_once ("../includes/signup-7-inc.php");?>
 
-<div id="top-page-image" class="top-page-image"></div>
+<div class="page-panel-group">
+  <div id="form-submission-box" class="landing-page-form" style="min-height:calc( 100vh - 54px)">
+    <div class="form-container">
 
-<div id="form-submission-box" class="landing-page-form">
-  <div class="form-container">
-    <div style="text-align:center;width:100%;margin:auto;">
-      <div class="emoji-banner" style="text-align:center;font-size:5em;">
-        <?= htmlspecialchars($earthling_emoji) ?>
+      <div id="top-page-image" class="top-page-image"></div>
+
+      <div style="text-align:center;width:100%;margin:auto;">
+        <div class="emoji-banner" style="text-align:center;font-size:5em;">
+          <?= htmlspecialchars($earthling_emoji) ?>
+        </div>
+        <h1>
+          <span data-lang-id="001-hurray">Hurray</span> <?= htmlspecialchars($first_name) ?>!
+        </h1>
+        <h4 data-lang-id="002-your-buwana-create">Your Buwana account has been created.</h4>
+        <p>
+          <span data-lang-id="003-you-will-be">You'll be redirected to login to </span><?= htmlspecialchars($app_display_name) ?> <span data-lang-id="004-after">after</span> <span id="countdown">5</span> <span data-lang-id="005-seconds">seconds</span>.
+        </p>
       </div>
-      <h1>
-        <span data-lang-id="001-hurray">Hurray</span> <?= htmlspecialchars($first_name) ?>!
-      </h1>
-      <h4 data-lang-id="002-your-buwana-create">Your Buwana account has been created.</h4>
-      <p>
-        <span data-lang-id="003-you-will-be">You'll be redirected to login to </span><?= htmlspecialchars($app_display_name) ?> <span data-lang-id="004-after">after</span> <span id="countdown">5</span> <span data-lang-id="005-seconds">seconds</span>.
-      </p>
+    </div>
 
-
+    <div id="browser-back-link" style="font-size: small; text-align: center; margin: auto; align-self: center; padding-top: 40px; padding-bottom: 40px; margin-top: 0px;">
+        <p><span data-lang-id="006-manual-redirect">If you're not redirected automatically,</span><a href="<?= htmlspecialchars($redirect_url) ?>"> <span data-lang-id="007-click-here">click here</span></a>.
+        </p>
     </div>
   </div>
-  <div id="browser-back-link" style="font-size: small; text-align: center; margin: auto; align-self: center; padding-top: 40px; padding-bottom: 40px; margin-top: 0px;">
-      <p><span data-lang-id="006-manual-redirect">If you're not redirected automatically,</span><a href="<?= htmlspecialchars($redirect_url) ?>"> <span data-lang-id="007-click-here">click here</span></a>.
-      </p>
-  </div>
-</div>
-
-
 </div>
 
 <?php require_once ("../footer-2025.php"); ?>


### PR DESCRIPTION
## Summary
- Wrap signup steps 4–7 in `.page-panel-group` and move their top images inside the form container for consistent layout.
- Add `min-height` styling to form panels and relocate browser back-links within the panel group.

## Testing
- `php -l en/signup-4.php`
- `php -l en/signup-5.php`
- `php -l en/signup-6.php`
- `php -l en/signup-7.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abe692f59c832b86c1d8903b71a1ea