### PR TITLE
Add legacy GoBrik account deletion

### DIFF
--- a/en/activate-gobrik-legacy.php
+++ b/en/activate-gobrik-legacy.php
@@ -124,7 +124,7 @@ $page_key = 'signup_1';
             <div class="form-item" style="margin: 70px 10px 40px 10px;">
                 <p style="text-align:center;"><span data-lang-id="0007-not-interested">If you're not interested and would like your old </span><?php echo htmlspecialchars($email_addr); ?><span data-lang-id="0009-that-too"> account completely deleted, you can do that too.</span></p>
                 <!-- DELETE ACCOUNT FORM -->
-                <form id="delete-account-form" method="post" action="../api/delete_accounts.php?id=<?php echo htmlspecialchars($ecobricker_id); ?>">
+                <form id="delete-account-form" method="post" action="../processes/delete_gobrik_account.php?id=<?php echo htmlspecialchars($ecobricker_id); ?>">
                     <div style="text-align:center;width:100%;margin:auto;margin-top:10px;margin-bottom:10px;">
                         <button type="button" class="submit-button delete" onclick="confirmDeletion()" data-lang-id="0010-delete-button">Delete My Account</button>
                     </div>
@@ -143,8 +143,8 @@ $page_key = 'signup_1';
 
 <script>
 function confirmDeletion() {
-    if (confirm("Are you certain you wish to delete your account? This cannot be undone.")) {
-        if (confirm("Ok. We will delete your account! Note that this does not affect ecobrick data that has been permanently archived in the brikchain. If you have a Buwana account and/or a subscription to our Earthen newsletter it will also be deleted.")) {
+    if (confirm("Are you certain you wish to delete your old GoBrik account? This cannot be undone.")) {
+        if (confirm("Ok. We'll delete your legacy GoBrik account. This does not affect ecobrick data archived in the brikchain, nor will it remove any Buwana account or Earthen newsletter subscription.")) {
             document.getElementById('delete-account-form').submit();
         }
     }

--- a/processes/delete_gobrik_account.php
+++ b/processes/delete_gobrik_account.php
@@ -1,0 +1,23 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+session_start();
+
+$ecobricker_id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $ecobricker_id > 0) {
+    require_once '../gobrikconn_env.php';
+
+    $stmt = $gobrik_conn->prepare('DELETE FROM tb_ecobrickers WHERE ecobricker_id = ?');
+    if ($stmt) {
+        $stmt->bind_param('i', $ecobricker_id);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    $gobrik_conn->close();
+}
+
+header('Location: https://gobrik.com/en/goodbye.php');
+exit();
+?>


### PR DESCRIPTION
## Summary
- add process to remove a legacy GoBrik account and redirect to goodbye page
- wire activation page's delete button to the new deletion process and clarify confirmation wording

## Testing
- `php -l processes/delete_gobrik_account.php`
- `php -l en/activate-gobrik-legacy.php`
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aee01be0d0832ba760bbc5056be8fa