### PR TITLE
fix: bypass client db but update buwana record

### DIFF
--- a/en/signup-6_process.php
+++ b/en/signup-6_process.php
@@ -13,15 +13,8 @@ require_once '../buwanaconn_env.php';
 require_once '../fetch_app_info.php';
 require_once '../scripts/create_user.php';
 
-// 🌿 Special handling for Learning Portal (Moodle SSO)
-$app_id = $_SESSION['app_id'] ?? null;
-
-if ($app_id === 'lear_a30d677a7b08') {
-    // 🌻 Skip DB logic & redirect to Moodle Learning Portal
-    header("Location: https://learning.ecobricks.org");
-    exit();
-}
-
+// 🌿 Capture active client id from session
+$session_client_id = $_SESSION['client_id'] ?? null;
 
 // --- STEP 1: Validate and extract inputs ---
 $buwana_id = $_GET['id'] ?? null;
@@ -79,10 +72,11 @@ $stmt->execute();
 $stmt->close();
 
 // --- STEP 5: Bypass full client provisioning if Learning Portal app ---
-if ($app_name === 'lear_a30d677a7b08') {
-    error_log("🌱 Skipping client provisioning for Learning Portal app ID: $app_name");
-
-    // Optional: Maybe even notify user via session or toast here
+if ($session_client_id === 'lear_a30d677a7b08') {
+    error_log("🌱 Skipping client provisioning for Learning Portal app ID: $session_client_id");
+    $connected_at = date('Y-m-d H:i:s');
+    updateAppConnectionStatus($buwana_conn, $buwana_id, $client_id, 'registered', $connected_at);
+    updateBuwanaUserNotes($buwana_conn, $buwana_id, $app_name, $connected_at);
 
     header("Location: signup-7.php?id=" . urlencode($buwana_id));
     exit();


### PR DESCRIPTION
## Summary
- remove early redirect so signup-6_process updates Buwana info before any bypass
- mark app connection registered when Learning Portal skips client provisioning

## Testing
- `php -l en/signup-6_process.php`
- `phpunit` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aeeab98990832ba78cb71214de83bf