### PR TITLE
refactor legacy email confirmation

### DIFF
--- a/en/confirm-email.php
+++ b/en/confirm-email.php
@@ -1,277 +1,69 @@
 <?php
-//<!-- For legacy gobrik email confirmation-->
-
+// For legacy gobrik email confirmation
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 session_start();
 
 require_once '../buwanaconn_env.php';
+require_once '../gobrikconn_env.php';
 require_once '../fetch_app_info.php';
-require_once '../earthenAuth_helper.php'; // Include the authentication helper functions
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
+$is_logged_in = false;
 
-
-$is_logged_in = false; // Ensure not logged in for this page
-
-$response = ['success' => false];
-$ecobricker_id = $_GET['id'] ?? null;
-
-// Page setup
 $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
-$version = '0.4';
-$page = 'activate';
-$version = '0.776';
-$lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
+$page = 'confirm-email';
+$version = '0.8';
+$lastModified = date('c');
 
-// Already logged in?
 if (!empty($_SESSION['buwana_id'])) {
     $redirect_url = $_SESSION['redirect_url'] ?? $app_info['app_url'] ?? '/';
-    echo "<script>
-        alert('Looks like you’re already logged in! Redirecting to your dashboard...');
-        window.location.href = '$redirect_url';
-    </script>";
+    echo "<script>\n        alert('Looks like you’re already logged in! Redirecting to your dashboard...');\n        window.location.href = '$redirect_url';\n    </script>";
     exit();
 }
 
-
-// PART 2: Check if ecobricker_id is passed in the URL
-if (is_null($ecobricker_id)) {
-    echo '<script>
-        alert("Hmm... something went wrong. No ecobricker ID was passed along. Please try logging in again. If this problem persists, you\'ll need to create a new account.");
-        window.location.href = "login.php";
-    </script>';
-    exit();
-}
-
-// Initialize user variables
 $ecobricker_id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);
+if (!$ecobricker_id) {
+    echo '<script>\n        alert("Hmm... something went wrong. No ecobricker ID was passed along. Please try logging in again. If this problem persists, you\'ll need to create a new account.");\n        window.location.href = "login.php";\n    </script>';
+    exit();
+}
+
 $first_name = '';
 $email_addr = '';
-$code_sent = false;
-$static_code = 'AYYEW';
+$buwana_id = null;
 $generated_code = '';
-$country_icon = '';
-$buwana_id = '';
+$code_sent_flag = false;
+$static_code = 'AYYEW';
 
-// PART 2: FUNCTIONS
-
-// Function to generate a random 5-character alphanumeric code
-function generateCode() {
-    return strtoupper(substr(bin2hex(random_bytes(3)), 0, 5));
+$sql_user = "SELECT first_name, email_addr, buwana_id FROM tb_ecobrickers WHERE ecobricker_id = ?";
+$stmt_user = $gobrik_conn->prepare($sql_user);
+if ($stmt_user) {
+    $stmt_user->bind_param('i', $ecobricker_id);
+    $stmt_user->execute();
+    $stmt_user->bind_result($first_name, $email_addr, $buwana_id);
+    $stmt_user->fetch();
+    $stmt_user->close();
 }
 
-// Function to send the verification code email using Mailgun API
-function sendVerificationCode($first_name, $email_addr, $verification_code, $lang) {
-    // Set up the Mailgun API client
-    $client = new Client(['base_uri' => 'https://api.eu.mailgun.net/v3/']); // EU endpoint for Mailgun
-    $mailgunApiKey = getenv('MAILGUN_API_KEY'); // Get Mailgun API key from environment
-    $mailgunDomain = 'mail.gobrik.com'; // Set Mailgun domain
-
-    // Determine the email content based on the language
-    switch ($lang) {
-        case 'fr':
-            $subject = 'Code de vérification GoBrik';
-            $html_body = "Bonjour $first_name!<br><br>Si vous lisez ceci, un code d'activation pour votre compte GoBrik et Buwana a été demandé ! Le code pour activer votre compte est :<br><br><b>$verification_code</b><br><br>Retournez à votre navigateur et entrez le code.<br><br>L'équipe GoBrik";
-            $text_body = "Bonjour $first_name! Si vous lisez ceci, un code d'activation pour votre compte GoBrik et Buwana a été demandé ! Le code pour activer votre compte est : $verification_code. Retournez à votre navigateur et entrez le code. L'équipe GoBrik";
-            break;
-        case 'es':
-            $subject = 'Código de verificación de GoBrik';
-            $html_body = "Hola $first_name!<br><br>¡Si estás leyendo esto, se ha solicitado un código de activación para tu cuenta de GoBrik y Buwana! El código para activar tu cuenta es:<br><br><b>$verification_code</b><br><br>Vuelve a tu navegador e ingresa el código.<br><br>El equipo de GoBrik";
-            $text_body = "Hola $first_name! Si estás leyendo esto, se ha solicitado un código de activación para tu cuenta de GoBrik y Buwana! El código para activar tu cuenta es: $verification_code. Vuelve a tu navegador e ingresa el código. El equipo de GoBrik";
-            break;
-        case 'id':
-            $subject = 'Kode Verifikasi GoBrik';
-            $html_body = "Halo $first_name!<br><br>Jika Anda membaca ini, kode aktivasi untuk akun GoBrik dan Buwana Anda telah diminta! Kode untuk mengaktifkan akun Anda adalah:<br><br><b>$verification_code</b><br><br>Kembali ke browser Anda dan masukkan kodenya.<br><br>Tim GoBrik";
-            $text_body = "Halo $first_name! Jika Anda membaca ini, kode aktivasi untuk akun GoBrik dan Buwana Anda telah diminta! Kode untuk mengaktifkan akun Anda adalah: $verification_code. Kembali ke browser Anda dan masukkan kodenya. Tim GoBrik";
-            break;
-        case 'en':
-        default:
-            $subject = 'GoBrik Verification Code';
-            $html_body = "Hello $first_name!<br><br>If you are reading this, an activation code for your GoBrik and Buwana account has been requested! The code to activate your account is:<br><br><b>$verification_code</b><br><br>Return back to your browser and enter the code.<br><br>The GoBrik team";
-            $text_body = "Hello $first_name! If you're reading this, an activation code for your GoBrik and Buwana account has been requested! The code to activate your account is: $verification_code. Return back to your browser and enter the code. The GoBrik team";
-            break;
-    }
-
-    try {
-        // Send the email using Mailgun's API
-        $response = $client->post("{$mailgunDomain}/messages", [
-            'auth' => ['api', $mailgunApiKey],
-            'form_params' => [
-                'from' => 'GoBrik Team <no-reply@mail.gobrik.com>', // Verified domain email
-                'to' => $email_addr,
-                'subject' => $subject,
-                'html' => $html_body,
-                'text' => $text_body, // Plain text fallback
-            ]
-        ]);
-
-        // Check response status
-        if ($response->getStatusCode() == 200) {
-            error_log("Mailgun: Verification email sent successfully to $email_addr");
-            return true;
-        } else {
-            error_log("Mailgun: Failed to send verification email. Status: " . $response->getStatusCode());
-            return false;
+if (!empty($buwana_id)) {
+    $sql_code = "SELECT activation_code FROM credentials_tb WHERE buwana_id = ? AND credential_type IN ('email','e-mail')";
+    $stmt_code = $buwana_conn->prepare($sql_code);
+    if ($stmt_code) {
+        $stmt_code->bind_param('i', $buwana_id);
+        $stmt_code->execute();
+        $stmt_code->bind_result($generated_code);
+        $stmt_code->fetch();
+        $stmt_code->close();
+        if (!empty($generated_code)) {
+            $code_sent_flag = true;
         }
-
-    } catch (RequestException $e) {
-        error_log("Mailgun API Exception: " . $e->getMessage());
-        return false;
     }
 }
-
-
-use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\PHPMailer\Exception;
-
-
-function backUpSMTPsender($first_name, $email_addr, $verification_code, $lang) {
-    $mail = new PHPMailer(true);
-
-    try {
-        // Enable SMTP debug output to logs (for development)
-        $mail->SMTPDebug = 2; // 0 = off, 2 = verbose
-        $mail->Debugoutput = function($str, $level) {
-            error_log("SMTP Debug [$level]: $str");
-        };
-
-        // Server settings
-        $mail->isSMTP();
-$mail->Host = getenv('SMTP_HOST');
-$mail->SMTPAuth = true;
-$mail->Username = getenv('SMTP_USERNAME');
-$mail->Password = getenv('SMTP_PASSWORD');
-$mail->Port = getenv('SMTP_PORT');
-
-// Disable encryption
-$mail->SMTPSecure = false;
-$mail->SMTPAutoTLS = false;
-
-        // Log basic SMTP config
-        error_log("SMTP fallback: Trying to send email using:");
-        error_log("Host: " . $mail->Host);
-        error_log("Port: " . $mail->Port);
-        error_log("Username: " . $mail->Username);
-        error_log("SMTPAuth: " . ($mail->SMTPAuth ? "true" : "false"));
-
-        // Sender & recipient
-        $mail->setFrom('gobrik@ecobricks.org', 'GoBrik Backup Mailer');
-        $mail->addAddress($email_addr, $first_name);
-
-        // Language-specific content
-        switch ($lang) {
-            case 'fr':
-                $subject = 'Code de vérification GoBrik';
-                $html_body = "Bonjour $first_name!<br><br>Votre code d'activation est : <b>$verification_code</b><br><br>Retournez à votre navigateur pour le saisir.<br><br>L'équipe GoBrik";
-                $text_body = "Bonjour $first_name! Votre code d'activation est : $verification_code. Retournez à votre navigateur pour le saisir. L'équipe GoBrik";
-                break;
-            case 'es':
-                $subject = 'Código de verificación de GoBrik';
-                $html_body = "Hola $first_name!<br><br>Tu código de activación es: <b>$verification_code</b><br><br>Vuelve a tu navegador para ingresarlo.<br><br>El equipo de GoBrik";
-                $text_body = "Hola $first_name! Tu código de activación es: $verification_code. Vuelve a tu navegador para ingresarlo. El equipo de GoBrik";
-                break;
-            case 'id':
-                $subject = 'Kode Verifikasi GoBrik';
-                $html_body = "Halo $first_name!<br><br>Kode aktivasi Anda adalah: <b>$verification_code</b><br><br>Kembali ke browser Anda untuk memasukkan kode.<br><br>Tim GoBrik";
-                $text_body = "Halo $first_name! Kode aktivasi Anda adalah: $verification_code. Kembali ke browser Anda untuk memasukkan kode. Tim GoBrik";
-                break;
-            case 'en':
-            default:
-                $subject = 'GoBrik Verification Code';
-                $html_body = "Hello $first_name!<br><br>Your activation code is: <b>$verification_code</b><br><br>Return to your browser and enter the code.<br><br>The GoBrik team";
-                $text_body = "Hello $first_name! Your activation code is: $verification_code. Return to your browser and enter the code. The GoBrik team";
-                break;
-        }
-
-        // Email content
-        $mail->isHTML(true);
-        $mail->Subject = $subject;
-        $mail->Body = $html_body;
-        $mail->AltBody = $text_body;
-
-        // Add timeouts and safety
-        $mail->Timeout = 10;
-        $mail->SMTPConnectTimeout = 10;
-        $mail->SMTPKeepAlive = false;
-
-        $mail->send();
-        error_log("✅ SMTP: Fallback verification email sent successfully to $email_addr");
-        return true;
-
-    } catch (\Throwable $e) {
-        error_log("🚨 PHPMailer Throwable Exception: " . $e->getMessage());
-        error_log("❌ PHPMailer ErrorInfo: " . $mail->ErrorInfo);
-        return false;
-    }
-}
-
-
-
-
-
-
-// PART 4: Look up user information using ecobricker_id provided in URL
-require_once("../gobrikconn_env.php");
-
-$sql_user_info = "SELECT first_name, email_addr, gobrik_migrated, buwana_id FROM tb_ecobrickers WHERE ecobricker_id = ?";
-$stmt_user_info = $gobrik_conn->prepare($sql_user_info);
-if ($stmt_user_info) {
-    $stmt_user_info->bind_param('i', $ecobricker_id);
-    $stmt_user_info->execute();
-    $stmt_user_info->bind_result($first_name, $email_addr, $gobrik_migrated, $buwana_id);
-    $stmt_user_info->fetch();
-    $stmt_user_info->close();
-} else {
-    die('Error preparing statement for fetching user info: ' . $gobrik_conn->error);
-}
-
-// Check if buwana_id is empty and handle accordingly (if needed)
-if (empty($buwana_id)) {
-    // Handle the case where buwana_id is null or empty
-    $buwana_id = null; // You can choose to set it to null or any default value if needed
-}
-
-
-// PART 5: Generate the code and update the activation_code field in the database
-$generated_code = generateCode();
-
-$sql_update_code = "UPDATE tb_ecobrickers SET activation_code = ? WHERE ecobricker_id = ?";
-$stmt_update_code = $gobrik_conn->prepare($sql_update_code);
-if ($stmt_update_code) {
-    $stmt_update_code->bind_param('si', $generated_code, $ecobricker_id);
-    $stmt_update_code->execute();
-    $stmt_update_code->close();
-} else {
-    die('Error preparing statement for updating activation code: ' . $gobrik_conn->error);
-}
-
-
-// PART 6: Handle form submission to send the confirmation code by email
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && (isset($_POST['send_email']) || isset($_POST['resend_email']))) {
-    $code_sent = sendVerificationCode($first_name, $email_addr, $generated_code, $lang);
-
-    if (!$code_sent) {
-        // Try backup SMTP method
-        $code_sent = backUpSMTPsender($first_name, $email_addr, $generated_code, $lang);
-    }
-
-if ($code_sent) {
-    $code_sent_flag = true;
-} else {
-    echo '<script>alert("We tried both our main and backup servers, but your verification email could not be sent. Please try again later or contact support.");</script>';
-    error_log("❌ Final email attempt failed.");
-}
-}
-
 
 $gobrik_conn->close();
-
+$buwana_conn->close();
 ?>
-
 <!DOCTYPE html>
-<html lang="<?php echo $lang; ?>">
+<html lang="<?= $lang; ?>">
 <head>
 <meta charset="UTF-8">
 <title>Confirm Your Email</title>
@@ -283,34 +75,30 @@ Developed and made open source by the Global Ecobrick Alliance
 See our git hub repository for the full code and to help out:
 https://github.com/gea-ecobricks/gobrik-3.0/tree/main/en-->
 
-
 <?php require_once ("../includes/activate-inc.php");?>
 
-
-<!-- PAGE CONTENT -->
-   <?php
-   $page_key = 'signup_3';
-   ?>
-
+</head>
+<body>
 <div class="page-panel-group">
     <div id="form-submission-box" class="landing-page-form">
         <div class="form-container" style="box-shadow: #0000001f 0px 5px 20px;">
 
             <div id="top-page-image"
                  class="top-page-image"
-                 data-light-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_light']) ?>"
-                 data-dark-img="<?= htmlspecialchars($app_info[$page_key . '_top_img_dark']) ?>">
+                 data-light-img="<?= htmlspecialchars($app_info['signup_3_top_img_light']) ?>"
+                 data-dark-img="<?= htmlspecialchars($app_info['signup_3_top_img_dark']) ?>">
             </div>
 
        <!-- Email confirmation form -->
 <div id="first-send-form" style="text-align:center;width:100%;margin:auto;margin-top:10px;margin-bottom:10px;"
-    class="<?php echo $code_sent ? 'hidden' : ''; ?>"> <!-- Fix the inline PHP inside attributes -->
+    class="<?php echo $code_sent_flag ? 'hidden' : ''; ?>">
 
     <h2><span data-lang-id="001-alright">Alright</span> <?php echo htmlspecialchars($first_name); ?>, <span data-lang-id="002-lets-confirm"> let's confirm your email.</span></h2>
     <p data-lang-id="003-to-create">To create your Buwana GoBrik account we need to confirm your chosen credential. This is how we'll keep in touch and keep your account secure.  Click the send button and we'll send an account activation code to:</p>
 
     <h3><?php echo htmlspecialchars($email_addr); ?></h3>
-    <form id="send-email-code" method="post" action="">
+    <form id="send-email-code" method="post" action="confirm-email_process.php?id=<?= htmlspecialchars($ecobricker_id); ?>">
+        <input type="hidden" name="lang" value="<?= htmlspecialchars($lang); ?>">
         <div style="text-align:center;width:100%;margin:auto;margin-top:10px;margin-bottom:10px;">
             <div id="submit-section" style="text-align:center;margin-top:20px;padding-right:15px;padding-left:15px" title="Start Activation process" data-lang-id="004-send-email-button">
                 <input type="submit" name="send_email" id="send_email" value="📨 Send Code" class="submit-button activate">
@@ -320,8 +108,7 @@ https://github.com/gea-ecobricks/gobrik-3.0/tree/main/en-->
 </div>
 
 <!-- Code entry form -->
-<div id="second-code-confirm" style="text-align:center;"
-    class="<?php echo !$code_sent ? 'hidden' : ''; ?>"> <!-- Fix the inline PHP inside attributes -->
+<div id="second-code-confirm" style="text-align:center;" class="<?php echo !$code_sent_flag ? 'hidden' : ''; ?>">
 
     <h2 data-lang-id="006-enter-code">Please enter your code:</h2>
     <p><span data-lang-id="007-check-email">Check your email</span> <?php echo htmlspecialchars($email_addr); ?> <span data-lang-id="008-for-your-code">for your account confirmation code. Enter it here:</span></p>
@@ -332,33 +119,29 @@ https://github.com/gea-ecobricks/gobrik-3.0/tree/main/en-->
         <input type="text" maxlength="1" class="code-box" required placeholder="-">
         <input type="text" maxlength="1" class="code-box" required placeholder="-">
         <input type="text" maxlength="1" class="code-box" required placeholder="-">
-    </form>
+    </div>
 
     <p id="code-feedback"></p>
 
     <p id="resend-code" style="font-size:1em"><span data-lang-id="009-no-code">Didn't get your code? You can request a resend of the code in</span> <span id="timer">1:00</span></p>
 </div>
 
-
-
-
-            <?php if (!empty($buwana_id)) : ?>
-            <div id="new-account-another-email-please" style="text-align:center;width:90%;margin:auto;margin-top:30px;margin-bottom:30px;">
-                <p style="font-size:1em;"><span data-lang-id="011-change-email">Want to change your email? </span>  <a href="signup-2.php?id=<?php echo htmlspecialchars($buwana_id); ?>"><span data-lang-id="012-go-back-new-email"> Go back to enter a different email address.</span></a>
-                </p>
-            </div>
-            <?php else : ?>
-            <div id="legacy-account-email-not-used" style="text-align:center;width:90%;margin:auto;margin-top:30px;margin-bottom:50px;">
-                <p style="font-size:1em;" data-lang-id="010-email-no-longer">Do you no longer use this email address?<br>If not, you'll need to <a href="signup.php">create a new account</a> or contact our team at support@gobrik.com.</p>
-            </div>
-            <?php endif; ?>
+<?php if (!empty($buwana_id)) : ?>
+<div id="new-account-another-email-please" style="text-align:center;width:90%;margin:auto;margin-top:30px;margin-bottom:30px;">
+    <p style="font-size:1em;"><span data-lang-id="011-change-email">Want to change your email? </span>  <a href="signup-2.php?id=<?php echo htmlspecialchars($buwana_id); ?>"><span data-lang-id="012-go-back-new-email"> Go back to enter a different email address.</span></a>
+    </p>
+</div>
+<?php else : ?>
+<div id="legacy-account-email-not-used" style="text-align:center;width:90%;margin:auto;margin-top:30px;margin-bottom:50px;">
+    <p style="font-size:1em;" data-lang-id="010-email-no-longer">Do you no longer use this email address?<br>If not, you'll need to <a href="signup.php">create a new account</a> or contact our team at support@gobrik.com.</p>
+</div>
+<?php endif; ?>
 
         </div>
     </div>
 </div>
 
 </div> <!--Closes main-->
-
 
 <!--FOOTER STARTS HERE-->
 <?php require_once ("../footer-2025.php"); ?>
@@ -367,11 +150,11 @@ https://github.com/gea-ecobricks/gobrik-3.0/tree/main/en-->
 document.addEventListener('DOMContentLoaded', function() {
     const staticCode = "AYYEW";
     const generatedCode = <?php echo json_encode($generated_code); ?>;
-    const ecobricker_id = <?php echo json_encode($ecobricker_id); ?>;
     const lang = '<?php echo $lang; ?>';
     let timeLeft = 60;
     const sendEmailForm = document.getElementById('send-email-code');
     const buwana_id = <?php echo json_encode($buwana_id); ?>;
+    const emailAddr = <?php echo json_encode($email_addr); ?>;
 
     const messages = {
         en: { confirmed: "👍 Code confirmed!", incorrect: "😕 Code incorrect. Try again." },
@@ -396,18 +179,16 @@ document.addEventListener('DOMContentLoaded', function() {
                 document.getElementById('resend-code').style.display = 'none';
 
                 setTimeout(function() {
-                    window.location.href = "activate_process.php?id=" + ecobricker_id + "&buwana_id=" + buwana_id;
+                    window.location.href = "signup-2.php?id=" + buwana_id + "&email=" + encodeURIComponent(emailAddr);
                 }, 300);
             } else {
                 codeFeedback.textContent = feedbackMessages.incorrect;
                 codeFeedback.classList.add('error');
                 codeFeedback.classList.remove('success');
                 shakeElement(document.getElementById('code-form'));
-
             }
         }
     }
-
 
     codeBoxes.forEach((box, index) => {
         box.addEventListener('keyup', function(e) {
@@ -420,7 +201,6 @@ document.addEventListener('DOMContentLoaded', function() {
         if (index === 0) {
             box.addEventListener('paste', function(e) {
                 const pastedText = (e.clipboardData || window.clipboardData).getData('text');
-
                 if (pastedText.length === 5) {
                     e.preventDefault();
                     codeBoxes.forEach((box, i) => box.value = pastedText[i] || '');
@@ -430,49 +210,33 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         }
 
-        // Add keydown event to handle backspacing
         box.addEventListener('keydown', function(e) {
             if (e.key === 'Backspace' && box.value === '' && index > 0) {
-                codeBoxes[index - 1].focus(); // Move to the previous box
+                codeBoxes[index - 1].focus();
             }
         });
     });
 
-
-
-
-
-
-    // Handle the resend code timer
     let countdownTimer = setInterval(function() {
         timeLeft--;
         if (timeLeft <= 0) {
             clearInterval(countdownTimer);
             document.getElementById('resend-code').innerHTML = '<a href="#" id="resend-link">Resend the code now.</a>';
-
-            // Add click event to trigger form submission
             document.getElementById('resend-link').addEventListener('click', function(event) {
-                event.preventDefault(); // Prevent default anchor behavior
-                sendEmailForm.submit(); // Submit the form programmatically
+                event.preventDefault();
+                sendEmailForm.submit();
             });
         } else {
             document.getElementById('timer').textContent = '0:' + (timeLeft < 10 ? '0' : '') + timeLeft;
         }
     }, 1000);
 
-
-
-    // Show/Hide Divs after email is sent
-    var codeSent = <?php echo json_encode($code_sent_flag ?? false); ?>;  // Only set once
+    var codeSent = <?php echo json_encode($code_sent_flag); ?>;
     if (codeSent) {
         document.getElementById('first-send-form').style.display = 'none';
         document.getElementById('second-code-confirm').style.display = 'block';
     }
-
-
 });
 </script>
-
-
 </body>
 </html>

--- a/en/confirm-email_process.php
+++ b/en/confirm-email_process.php
@@ -1,0 +1,177 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+session_start();
+
+require_once '../buwanaconn_env.php';
+require_once '../gobrikconn_env.php';
+require_once '../fetch_app_info.php';
+require '../vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+function generateCode() {
+    return strtoupper(substr(bin2hex(random_bytes(3)), 0, 5));
+}
+
+function sendVerificationCode($first_name, $email_addr, $code, $lang) {
+    $client = new Client(['base_uri' => 'https://api.eu.mailgun.net/v3/']);
+    $apiKey = getenv('MAILGUN_API_KEY');
+    $domain = 'mail.gobrik.com';
+
+    switch ($lang) {
+        case 'fr':
+            $subject = 'Code de vérification GoBrik';
+            $html = "Bonjour $first_name!<br><br>Votre code d'activation est : <b>$code</b><br><br>Retournez à votre navigateur pour le saisir.<br><br>L'équipe GoBrik";
+            $text = "Bonjour $first_name! Votre code d'activation est : $code. Retournez à votre navigateur pour le saisir. L'équipe GoBrik";
+            break;
+        case 'es':
+            $subject = 'Código de verificación de GoBrik';
+            $html = "Hola $first_name!<br><br>Tu código de activación es: <b>$code</b><br><br>Vuelve a tu navegador para ingresarlo.<br><br>El equipo de GoBrik";
+            $text = "Hola $first_name! Tu código de activación es: $code. Vuelve a tu navegador para ingresarlo. El equipo de GoBrik";
+            break;
+        case 'id':
+            $subject = 'Kode Verifikasi GoBrik';
+            $html = "Halo $first_name!<br><br>Kode aktivasi Anda adalah: <b>$code</b><br><br>Kembali ke browser Anda untuk memasukkan kode.<br><br>Tim GoBrik";
+            $text = "Halo $first_name! Kode aktivasi Anda adalah: $code. Kembali ke browser Anda untuk memasukkan kode. Tim GoBrik";
+            break;
+        case 'en':
+        default:
+            $subject = 'GoBrik Verification Code';
+            $html = "Hello $first_name!<br><br>Your activation code is: <b>$code</b><br><br>Return to your browser and enter the code.<br><br>The GoBrik team";
+            $text = "Hello $first_name! Your activation code is: $code. Return to your browser and enter the code. The GoBrik team";
+            break;
+    }
+
+    try {
+        $response = $client->post("{$domain}/messages", [
+            'auth' => ['api', $apiKey],
+            'form_params' => [
+                'from' => 'GoBrik Team <no-reply@mail.gobrik.com>',
+                'to' => $email_addr,
+                'subject' => $subject,
+                'html' => $html,
+                'text' => $text,
+            ]
+        ]);
+        return $response->getStatusCode() === 200;
+    } catch (RequestException $e) {
+        error_log('Mailgun error: ' . $e->getMessage());
+        return false;
+    }
+}
+
+function backUpSMTPsender($first_name, $email_addr, $code) {
+    $mail = new PHPMailer(true);
+    try {
+        $mail->isSMTP();
+        $mail->Host = getenv('SMTP_HOST');
+        $mail->SMTPAuth = true;
+        $mail->Username = getenv('SMTP_USERNAME');
+        $mail->Password = getenv('SMTP_PASSWORD');
+        $mail->Port = getenv('SMTP_PORT');
+        $mail->SMTPSecure = false;
+        $mail->SMTPAutoTLS = false;
+
+        $mail->setFrom('gobrik@ecobricks.org', 'GoBrik Backup Mailer');
+        $mail->addAddress($email_addr, $first_name);
+
+        $mail->isHTML(true);
+        $mail->Subject = 'GoBrik Verification Code';
+        $mail->Body = "Hello $first_name!<br><br>Your activation code is: <b>$code</b><br><br>Return to your browser and enter the code.<br><br>The GoBrik team";
+        $mail->AltBody = "Hello $first_name! Your activation code is: $code. Return to your browser and enter the code. The GoBrik team";
+
+        $mail->send();
+        return true;
+    } catch (\Throwable $e) {
+        error_log('PHPMailer error: ' . $e->getMessage());
+        return false;
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $ecobricker_id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);
+    $lang = $_POST['lang'] ?? 'en';
+    if (!$ecobricker_id) {
+        die('Missing ecobricker ID');
+    }
+
+    $first_name = $email_addr = '';
+    $buwana_id = null;
+
+    $sql = "SELECT first_name, email_addr, buwana_id FROM tb_ecobrickers WHERE ecobricker_id = ?";
+    $stmt = $gobrik_conn->prepare($sql);
+    $stmt->bind_param('i', $ecobricker_id);
+    $stmt->execute();
+    $stmt->bind_result($first_name, $email_addr, $buwana_id);
+    $stmt->fetch();
+    $stmt->close();
+
+    if (!$email_addr) {
+        die('Email not found');
+    }
+
+    $generated_code = generateCode();
+    $created_at = $last_login = date('Y-m-d H:i:s');
+
+    if (!$buwana_id) {
+        $account_status = 'legacy account activated';
+        $role = 'ecobricker';
+        $notes = 'Legacy activation complete but password not yet reset';
+
+        $sql_user = "INSERT INTO users_tb (first_name, full_name, created_at, last_login, account_status, role, notes) VALUES (?, ?, ?, ?, ?, ?, ?)";
+        $stmt_user = $buwana_conn->prepare($sql_user);
+        $full_name = $first_name;
+        $stmt_user->bind_param('sssssss', $first_name, $full_name, $created_at, $last_login, $account_status, $role, $notes);
+        $stmt_user->execute();
+        $buwana_id = $buwana_conn->insert_id;
+        $stmt_user->close();
+
+        $client_id = $_SESSION['client_id'] ?? $default_client_id;
+        $sql_connect = "INSERT INTO user_app_connections_tb (buwana_id, client_id) VALUES (?, ?)";
+        $stmt_connect = $buwana_conn->prepare($sql_connect);
+        $stmt_connect->bind_param('is', $buwana_id, $client_id);
+        $stmt_connect->execute();
+        $stmt_connect->close();
+    }
+
+    $sql_check = "SELECT credential_id FROM credentials_tb WHERE buwana_id = ? AND credential_type IN ('email','e-mail')";
+    $stmt_check = $buwana_conn->prepare($sql_check);
+    $stmt_check->bind_param('i', $buwana_id);
+    $stmt_check->execute();
+    $stmt_check->bind_result($credential_id);
+    $stmt_check->fetch();
+    $stmt_check->close();
+
+    if ($credential_id) {
+        $sql_update = "UPDATE credentials_tb SET credential_key = ?, activation_code = ?, last_login = ? WHERE credential_id = ?";
+        $stmt_update = $buwana_conn->prepare($sql_update);
+        $stmt_update->bind_param('sssi', $email_addr, $generated_code, $last_login, $credential_id);
+        $stmt_update->execute();
+        $stmt_update->close();
+    } else {
+        $sql_cred = "INSERT INTO credentials_tb (buwana_id, credential_type, credential_key, activation_code, times_used, failed_password_count, last_login) VALUES (?, 'email', ?, ?, 0, 0, ?)";
+        $stmt_cred = $buwana_conn->prepare($sql_cred);
+        $stmt_cred->bind_param('isss', $buwana_id, $email_addr, $generated_code, $last_login);
+        $stmt_cred->execute();
+        $stmt_cred->close();
+    }
+
+    $sql_update_gobrik = "UPDATE tb_ecobrickers SET buwana_id = ? WHERE ecobricker_id = ?";
+    $stmt_update_gobrik = $gobrik_conn->prepare($sql_update_gobrik);
+    $stmt_update_gobrik->bind_param('ii', $buwana_id, $ecobricker_id);
+    $stmt_update_gobrik->execute();
+    $stmt_update_gobrik->close();
+
+    $sent = sendVerificationCode($first_name, $email_addr, $generated_code, $lang);
+    if (!$sent) {
+        $sent = backUpSMTPsender($first_name, $email_addr, $generated_code);
+    }
+
+    header('Location: confirm-email.php?id=' . $ecobricker_id . '&sent=1');
+    exit();
+}
+?>


### PR DESCRIPTION
## Summary
- modernize legacy email confirmation flow
- create `confirm-email_process.php` to send codes and initialize Buwana accounts
- streamline `confirm-email.php` and redirect verified users to signup step 2 with prefilled email

## Testing
- `php -l en/confirm-email_process.php`
- `php -l en/confirm-email.php`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b7a39e7ebc832bb625726e5df2dd14