### PR TITLE
Handle confirm email verification via POST

### DIFF
--- a/en/confirm-email.php
+++ b/en/confirm-email.php
@@ -139,8 +139,19 @@ document.addEventListener('DOMContentLoaded', function() {
     const feedbackMessages = messages[lang] || messages.en;
 
     function sendVerificationEmail() {
-        fetch('confirm-email_process.php?id=' + ecobricker_id, { method: 'POST' })
-        .then(response => response.json())
+        const params = new URLSearchParams();
+        params.append('id', ecobricker_id);
+
+        fetch('confirm-email_process.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params,
+            credentials: 'same-origin'
+        })
+        .then(response => {
+            if (!response.ok) throw new Error('Network response was not ok');
+            return response.json();
+        })
         .then(data => {
             if (data.success) {
                 generatedCode = data.code;

--- a/en/confirm-email_process.php
+++ b/en/confirm-email_process.php
@@ -15,7 +15,7 @@ use GuzzleHttp\Exception\RequestException;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 
-$ecobricker_id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);
+$ecobricker_id = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
 if (!$ecobricker_id) {
     echo json_encode(['success' => false, 'message' => 'missing_id']);
     exit();


### PR DESCRIPTION
## Summary
- send confirmation request via POST body instead of query string
- read ecobricker id from POST in confirm-email_process

## Testing
- `php -l en/confirm-email.php`
- `php -l en/confirm-email_process.php`
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9108d1bbc832b9414c2b8bc484550