### PR TITLE
Handle legacy account upgrade on signup

### DIFF
--- a/en/signup-2.php
+++ b/en/signup-2.php
@@ -165,7 +165,7 @@ https://github.com/gea-ecobricks/buwana/-->
 
                    <div id="loading-spinner" class="spinner" style="display: none;margin-left: 10px;margin-top: 7px;"></div>
 
-                   <p class="form-caption" data-lang-id="007-email-sub-caption" style="margin-bottom: -10px;">💌 We'll use this email to confirm your account.</p>
+                   <p id="email-caption" class="form-caption" data-lang-id="007-email-sub-caption" style="margin-bottom: -10px;">💌 We'll use this email to confirm your account.</p>
                  </div>
 
 
@@ -252,6 +252,17 @@ $(document).ready(function () {
   const duplicateGobrikEmail = $('#duplicate-gobrik-email');
   const loadingSpinner = $('#loading-spinner');
   const accountStatus = <?php echo json_encode($account_status); ?>;
+  const emailCaption = document.getElementById('email-caption');
+  const submitButtonText = document.getElementById('submit-button-text');
+
+  if (accountStatus === 'legacy account activated') {
+    if (emailCaption) {
+      emailCaption.textContent = "👍 Let's go ahead and upgrade your legacy GoBrik account to the Buwana system!";
+    }
+    if (submitButtonText) {
+      submitButtonText.textContent = 'Upgrade Account';
+    }
+  }
 
   // === Initial UI State ===
   setPasswordSection.style.display = 'none';

--- a/en/signup-2_process.php
+++ b/en/signup-2_process.php
@@ -51,12 +51,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
         error_log("🚨 High bot score signup detected: Buwana ID $buwana_id with score $bot_score");
     }
 
-    // 🛠️ Fetch user's first name
-    $stmt = $buwana_conn->prepare("SELECT first_name FROM users_tb WHERE buwana_id = ?");
+    // 🛠️ Fetch user's first name and account status
+    $stmt = $buwana_conn->prepare("SELECT first_name, account_status FROM users_tb WHERE buwana_id = ?");
     if (!$stmt) sendJsonError('db_error_first_name');
     $stmt->bind_param("i", $buwana_id);
     $stmt->execute();
-    $stmt->bind_result($first_name);
+    $stmt->bind_result($first_name, $account_status);
     $stmt->fetch();
     $stmt->close();
 
@@ -103,7 +103,11 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
 
     // 🎉 Success
     $response['success'] = true;
-    $response['redirect'] = "signup-3.php?id=" . urlencode($buwana_id);
+    if ($account_status === 'legacy account activated') {
+        $response['redirect'] = "signup-4.php?id=" . urlencode($buwana_id);
+    } else {
+        $response['redirect'] = "signup-3.php?id=" . urlencode($buwana_id);
+    }
 }
 
 ob_end_clean();


### PR DESCRIPTION
## Summary
- Show upgrade message and adjust submit button when legacy GoBrik users register
- Redirect legacy account upgrades straight to step 4 after signup

## Testing
- `php -l en/signup-2.php`
- `php -l en/signup-2_process.php`
- `phpunit --version` *(fails: command not found)*
- `composer global require phpunit/phpunit` *(fails: curl error 56: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b92af7cd8c832bba96a761722b63b9