### PR TITLE
Allow legacy Buwana accounts to reuse existing email

### DIFF
--- a/scripts/check_email.php
+++ b/scripts/check_email.php
@@ -16,7 +16,8 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     }
 
     // Check if the email already exists in the Buwana database
-    $sql_check_email = "SELECT COUNT(*) FROM users_tb WHERE email = ?";
+    // Ignore users with the 'legacy account activated' status
+    $sql_check_email = "SELECT COUNT(*) FROM users_tb WHERE email = ? AND account_status <> 'legacy account activated'";
     $stmt_check_email = $buwana_conn->prepare($sql_check_email);
     if ($stmt_check_email) {
         $stmt_check_email->bind_param("s", $credential_value);


### PR DESCRIPTION
## Summary
- Skip duplicate email error for legacy Buwana accounts marked 'legacy account activated'

## Testing
- `php -l scripts/check_email.php`
- `vendor/bin/phpunit` *(fails: No such file or directory; apt-get update 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b93bca18f4832b8a1d8fac70623752