### PR TITLE
Support legacy signup upgrades

### DIFF
--- a/en/signup-2.php
+++ b/en/signup-2.php
@@ -218,7 +218,10 @@ https://github.com/gea-ecobricks/buwana/-->
 
                <div style="display:flex;" class="form-item">
                  <input type="checkbox" id="terms" name="terms" required checked>
-                 <div class="form-caption"><span data-lang-id="015-by-registering">By registering today, I agree to the </span><a href="#" onclick="openTermsModal(); return false;" class="underline-link"><?= $app_info['app_display_name']; ?> <span data-lang-id="1000-terms-of-use">Terms of Use</a>.
+                 <div id="terms-check-text" class="form-caption">
+                   <span data-lang-id="<?= $is_legacy ? '015b-by-upgrading' : '015-by-registering' ?>">
+                     <?= $is_legacy ? 'By upgrading my account today, I agree to the new ' : 'By registering today, I agree to the ' ?>
+                   </span><a href="#" onclick="openTermsModal(); return false;" class="underline-link"><?= $app_info['app_display_name']; ?> <span data-lang-id="1000-terms-of-use">Terms of Use</span></a>.
                  </div>
                </div>
 
@@ -229,7 +232,7 @@ https://github.com/gea-ecobricks/buwana/-->
              <!-- Kick-Ass Submit Button -->
              <div id="submit-section" style="display:none;" class="submit-button-wrapper">
                <button type="submit" id="submit-button" class="kick-ass-submit disabled" title="Be sure you wrote ecobrick correctly!">
-                 <span id="submit-button-text" data-lang-id="016-register-button">Register ➡</span>
+                 <span id="submit-button-text" data-lang-id="<?= $is_legacy ? '016-upgrade-button' : '016-register-button' ?>"><?= $is_legacy ? 'Upgrade Account ➡' : 'Register ➡' ?></span>
                  <span id="submit-emoji" class="submit-emoji" style="display: none;"></span>
                </button>
              </div>
@@ -266,12 +269,16 @@ $(document).ready(function () {
   const duplicateGobrikEmail = $('#duplicate-gobrik-email');
   const loadingSpinner = $('#loading-spinner');
   const accountStatus = <?php echo json_encode($account_status); ?>;
-  const submitButtonText = document.getElementById('submit-button-text');
+  const credentialSection = document.getElementById('credential-section');
 
   if (accountStatus === 'legacy account activated') {
-    if (submitButtonText) {
-      submitButtonText.textContent = 'Upgrade Account';
+    if (credentialSection) {
+      credentialSection.style.display = 'block';
     }
+    setPasswordSection.style.display = 'block';
+    confirmPasswordSection.style.display = 'block';
+    humanCheckSection.style.display = 'block';
+    submitSection.style.display = 'block';
   }
 
   // === Initial UI State ===

--- a/translations/signup-2-ar.js
+++ b/translations/signup-2-ar.js
@@ -20,4 +20,6 @@ const ar_Page_Translations = {
     "014-is-spelled": " تُكتب بدون فراغ، أو حرف كبير، أو واصلة!",
     "015-by-registering": "من خلال التسجيل اليوم، أوافق على ",
     "016-register-button": "تسجيل ➡",
+    "015b-by-upgrading": "من خلال ترقية حسابي اليوم، أوافق على ",
+    "016-upgrade-button": "ترقية الحساب ➡",
 };

--- a/translations/signup-2-de.js
+++ b/translations/signup-2-de.js
@@ -23,4 +23,6 @@ const de_Page_Translations = {
     "014-is-spelled": " wird ohne Leerzeichen, Großbuchstaben oder Bindestrich geschrieben!",
     "015-by-registering": "Mit der heutigen Registrierung stimme ich den ",
     "016-register-button": "Registrieren ➡",
+    "015b-by-upgrading": "Durch das heutige Aktualisieren meines Kontos stimme ich den neuen ",
+    "016-upgrade-button": "Konto aktualisieren ➡",
 };

--- a/translations/signup-2-en.js
+++ b/translations/signup-2-en.js
@@ -26,6 +26,8 @@ const en_Page_Translations = {
     "014-is-spelled": " is spelled without a space, capital or hyphen!",
     "015-by-registering": "By registering today, I agree to the ",
     "016-register-button": "Register ➡",
+    "015b-by-upgrading": "By upgrading my account today, I agree to the new ",
+    "016-upgrade-button": "Upgrade Account ➡",
 
 };
 

--- a/translations/signup-2-es.js
+++ b/translations/signup-2-es.js
@@ -23,4 +23,6 @@ const es_Page_Translations = {
     "014-is-spelled": " se escribe sin espacio, mayúscula ni guion.",
     "015-by-registering": "Al registrarme hoy, acepto los ",
     "016-register-button": "Registrarse ➡",
+    "015b-by-upgrading": "Al actualizar mi cuenta hoy, acepto los nuevos ",
+    "016-upgrade-button": "Actualizar cuenta ➡",
 };

--- a/translations/signup-2-fr.js
+++ b/translations/signup-2-fr.js
@@ -20,4 +20,6 @@ const fr_Page_Translations = {
     "014-is-spelled": " s'écrit sans espace, majuscule ni tiret !",
     "015-by-registering": "En vous inscrivant aujourd'hui, j'accepte les ",
     "016-register-button": "S'inscrire ➡",
+    "015b-by-upgrading": "En mettant à niveau mon compte aujourd'hui, j'accepte les nouvelles ",
+    "016-upgrade-button": "Mettre à niveau le compte ➡",
 };

--- a/translations/signup-2-id.js
+++ b/translations/signup-2-id.js
@@ -20,4 +20,6 @@ const id_Page_Translations = {
     "014-is-spelled": " ditulis tanpa spasi, huruf kapital, atau tanda hubung!",
     "015-by-registering": "Dengan mendaftar hari ini, saya setuju dengan ",
     "016-register-button": "Daftar ➡",
+    "015b-by-upgrading": "Dengan meningkatkan akun saya hari ini, saya setuju dengan ",
+    "016-upgrade-button": "Tingkatkan Akun ➡",
 };

--- a/translations/signup-2-zh.js
+++ b/translations/signup-2-zh.js
@@ -23,4 +23,6 @@ const zh_Page_Translations = {
     "014-is-spelled": " 的拼写中没有空格、大写或连字符！",
     "015-by-registering": "我在此注册，即表示同意 ",
     "016-register-button": "注册 ➡",
+    "015b-by-upgrading": "通过今天升级我的账户，我同意新的 ",
+    "016-upgrade-button": "升级账户 ➡",
 };


### PR DESCRIPTION
## Summary
- Auto-display signup email and password sections for legacy accounts
- Use upgrade-specific language keys for terms text and submit button
- Add translation strings for upgrade flow in all supported languages

## Testing
- `php -l en/signup-2.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b961d9ddb4832bbe2335621f1e7392