### PR TITLE
Simplify legacy signup welcome and update translations

### DIFF
--- a/en/signup-2.php
+++ b/en/signup-2.php
@@ -133,7 +133,13 @@ https://github.com/gea-ecobricks/buwana/-->
             </div>
 
             <div style="text-align:center;width:100%;margin:auto;">
-                <h2 id="main-welcome"><span data-lang-id="<?= $is_legacy ? '001-activate-by' : '001-register-by' ?>"></span> <?php echo $credential_type; ?></h2>
+                <h2 id="main-welcome">
+                    <?php if ($is_legacy): ?>
+                        <span data-lang-id="001-activate-by"></span>
+                    <?php else: ?>
+                        <span data-lang-id="001-register-by"></span> <?= $credential_type ?>
+                    <?php endif; ?>
+                </h2>
                 <p id="sub-welcome">Ok <?php echo $first_name; ?>!
                     <?php if ($is_legacy): ?>
                         <span data-lang-id="001-now-lets-reset"></span>

--- a/translations/signup-2-ar.js
+++ b/translations/signup-2-ar.js
@@ -1,6 +1,6 @@
 const ar_Page_Translations = {
     "001-register-by": "سجل عن طريق",
-    "001-activate-by": "قم بتفعيل",
+    "001-activate-by": "قم بترقية حساب GoBrik الخاص بك",
     "002-now-lets-use": "دعنا نُعد حسابك على ",
     "001-now-lets-reset": "الآن دعنا نعيد تعيين كلمة مرورك ومعلومات حسابك الأساسية.",
     "003-to-register-on": "للتسجيل على ",

--- a/translations/signup-2-de.js
+++ b/translations/signup-2-de.js
@@ -3,7 +3,7 @@ TEXT TRANSLATION SNIPPETS FOR signup-2.php
 -----------------------------------*/
 const de_Page_Translations = {
     "001-register-by": "Registrieren mit",
-    "001-activate-by": "Aktiviere dein",
+    "001-activate-by": "Aktualisiere dein GoBrik-Konto",
     "002-now-lets-use": "Lass uns dein Konto einrichten auf ",
     "001-now-lets-reset": "jetzt setzen wir dein Passwort und die wichtigsten Kontoinformationen zurück.",
     "003-to-register-on": "um dich zu registrieren auf ",

--- a/translations/signup-2-en.js
+++ b/translations/signup-2-en.js
@@ -6,7 +6,7 @@ ENGLISH TRANSLATIONS FOR signup-2.php
 const en_Page_Translations = {
 
     "001-register-by": "Register by",
-    "001-activate-by": "Activate your",
+    "001-activate-by": "Upgrade your GoBrik Account",
     "002-now-lets-use": "Let's set you up on ",
     "001-now-lets-reset": "now let's reset your password and core account information.",
     "003-to-register-on": "to register on ",

--- a/translations/signup-2-es.js
+++ b/translations/signup-2-es.js
@@ -3,7 +3,7 @@ TEXT TRANSLATION SNIPPETS FOR signup-2.php
 -----------------------------------*/
 const es_Page_Translations = {
     "001-register-by": "Registrarse con",
-    "001-activate-by": "Activa tu",
+    "001-activate-by": "Actualiza tu cuenta GoBrik",
     "002-now-lets-use": "Ahora vamos a configurar tu cuenta en ",
     "001-now-lets-reset": "ahora vamos a restablecer tu contraseña y la información principal de tu cuenta.",
     "003-to-register-on": "para registrarte en ",

--- a/translations/signup-2-fr.js
+++ b/translations/signup-2-fr.js
@@ -1,6 +1,6 @@
 const fr_Page_Translations = {
     "001-register-by": "S'inscrire avec",
-    "001-activate-by": "Active ton",
+    "001-activate-by": "Mets à niveau ton compte GoBrik",
     "002-now-lets-use": "Mettons en place votre compte sur ",
     "001-now-lets-reset": "maintenant, réinitialisons votre mot de passe et les informations principales de votre compte.",
     "003-to-register-on": "pour vous inscrire sur ",

--- a/translations/signup-2-id.js
+++ b/translations/signup-2-id.js
@@ -1,6 +1,6 @@
 const id_Page_Translations = {
     "001-register-by": "Daftar dengan",
-    "001-activate-by": "Aktifkan",
+    "001-activate-by": "Tingkatkan Akun GoBrik Anda",
     "002-now-lets-use": "Sekarang mari kita atur akun Anda di ",
     "001-now-lets-reset": "sekarang mari kita atur ulang kata sandi dan informasi inti akun Anda.",
     "003-to-register-on": "untuk mendaftar di ",

--- a/translations/signup-2-zh.js
+++ b/translations/signup-2-zh.js
@@ -3,7 +3,7 @@ TEXT TRANSLATION SNIPPETS FOR signup-2.php
 -----------------------------------*/
 const zh_Page_Translations = {
     "001-register-by": "注册方式",
-    "001-activate-by": "激活你的",
+    "001-activate-by": "升级你的 GoBrik 账户",
     "002-now-lets-use": "现在让我们为你设置账户：",
     "001-now-lets-reset": "现在让我们重设你的密码和账户核心信息。",
     "003-to-register-on": "在此注册：",


### PR DESCRIPTION
## Summary
- Show only the upgrade message for legacy users on signup step 2
- Update `001-activate-by` snippet to "Upgrade your GoBrik Account" across all translations

## Testing
- `php -l en/signup-2.php`
- `phpunit` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b97720f654832bafc8156d392a7c32