### PR TITLE
Fix account deletion button

### DIFF
--- a/en/edit-profile.php
+++ b/en/edit-profile.php
@@ -1176,7 +1176,7 @@ function confirmDeletion(ecobrickerId, lang = 'en') {
         if (confirm("Ok. We will delete your account! Note that this does not affect ecobrick data that has been permanently archived in the brikchain. If you have a Buwana account and/or a subscription to our Earthen newsletter it will also be deleted.")) {
 
             // Send request to delete the user
-            fetch('../api/delete_accounts.php?id=' + encodeURIComponent(ecobrickerId))
+            fetch('../processes/delete_accounts.php?id=' + encodeURIComponent(ecobrickerId))
                 .then(response => response.json())
                 .then(data => {
                     if (data.success && data.redirect) {


### PR DESCRIPTION
## Summary
- Ensure profile deletion button calls the correct processes endpoint

## Testing
- `phpunit tests/EarthenAuthHelperTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be5cd52620832bb57a09716f79ecb6