### PR TITLE
Add goodbye page for account deletion confirmation

### DIFF
--- a/en/goodbye.php
+++ b/en/goodbye.php
@@ -1,0 +1,39 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+session_start();
+
+require_once '../buwanaconn_env.php';
+require_once '../fetch_app_info.php';
+
+$lang = basename(dirname($_SERVER['SCRIPT_NAME']));
+$page = 'goodbye';
+$version = '0.1';
+$lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
+?>
+
+<!DOCTYPE html>
+<html lang="<?= htmlspecialchars($lang) ?>">
+<head>
+  <meta charset="UTF-8">
+<?php require_once ("../includes/goodbye-inc.php");?>
+
+<!-- PAGE CONTENT -->
+<div id="top-page-image" class="regen-top top-page-image"></div>
+
+<div id="form-submission-box" class="landing-page-form">
+    <div class="form-container">
+
+      <div style="text-align:center;width:100%;margin:auto;">
+
+        <h1 data-lang-id="001-good-bye">Goodbye!</h1>
+        <p data-lang-id="002-successfuly-deleted">Your account has been successfully deleted.</p>
+        <p data-lang-id="003-change-mind">If you change your mind, you can <a href="signup-1.php">create a new account</a> anytime.</p>
+      </div>
+    </div>
+</div>
+
+<?php require_once ("../footer-2025.php");?>
+
+</body>
+</html>

--- a/includes/goodbye-inc.php
+++ b/includes/goodbye-inc.php
@@ -1,0 +1,2 @@
+<?php require_once ("../meta/$page-$lang.php");?>
+<?php require_once ("../header-2025.php");?>


### PR DESCRIPTION
## Summary
- Add `en/goodbye.php` using getting-started structure to display account deletion confirmation and signup link
- Create `includes/goodbye-inc.php` to load meta tags and header

## Testing
- `php -l en/goodbye.php`
- `php -l includes/goodbye-inc.php`
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bea0e65ed8832b80f7e0cf7e8e507f