### PR TITLE
Stop forwarding status to client apps

### DIFF
--- a/processes/login_process_jwt.php
+++ b/processes/login_process_jwt.php
@@ -26,7 +26,6 @@ $password = $_POST['password'] ?? '';
 $lang = $_POST['lang'] ?? 'en';
 
 $redirect = filter_var($_POST['redirect'] ?? '', FILTER_SANITIZE_SPECIAL_CHARS);
-$status   = isset($_POST['status']) ? filter_var($_POST['status'], FILTER_SANITIZE_SPECIAL_CHARS) : '';
 $client_id = $_POST['client_id'] ?? ($_SESSION['client_id'] ?? null);
 $csrf_token = $_POST['csrf_token'] ?? '';
 
@@ -240,10 +239,6 @@ if ($stmt_credential) {
                         $redirect_url = $app_dashboard_url;
                     }
 
-                    if (!empty($status) && $status !== 'loggedout') {
-                        $delimiter = (strpos($redirect_url, '?') !== false) ? '&' : '?';
-                        $redirect_url .= $delimiter . 'status=' . urlencode($status);
-                    }
                     header("Location: $redirect_url");
                     exit();
                 } else {


### PR DESCRIPTION
## Summary
- Remove status parameter from JWT login processing so client apps receive clean redirects

## Testing
- `php -l processes/login_process_jwt.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be9186d4a4832b96fd8ab63c203fec