### PR TITLE
Track account deletions and report results

### DIFF
--- a/en/goodbye.php
+++ b/en/goodbye.php
@@ -10,6 +10,8 @@ $lang = basename(dirname($_SERVER['SCRIPT_NAME']));
 $page = 'goodbye';
 $version = '0.1';
 $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
+$successes = isset($_GET['successes']) ? (array)$_GET['successes'] : [];
+$failures = isset($_GET['failures']) ? (array)$_GET['failures'] : [];
 ?>
 
 <!DOCTYPE html>
@@ -28,6 +30,20 @@ $lastModified = date("Y-m-d\TH:i:s\Z", filemtime(__FILE__));
 
         <h1 data-lang-id="001-good-bye">Goodbye!</h1>
         <p data-lang-id="002-successfuly-deleted">Your account has been successfully deleted.</p>
+        <?php if (!empty($successes)) : ?>
+          <ul style="list-style:none;padding:0;">
+            <?php foreach ($successes as $item) : ?>
+              <li>✅ <?= htmlspecialchars($item) ?></li>
+            <?php endforeach; ?>
+          </ul>
+        <?php endif; ?>
+        <?php if (!empty($failures)) : ?>
+          <ul style="list-style:none;padding:0;">
+            <?php foreach ($failures as $item) : ?>
+              <li>❌ <?= htmlspecialchars($item) ?></li>
+            <?php endforeach; ?>
+          </ul>
+        <?php endif; ?>
         <p data-lang-id="003-change-mind">If you change your mind, you can <a href="signup-1.php">create a new account</a> anytime.</p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Track success and failure of each account deletion and unsubscribe step in `delete_accounts.php`, returning them via redirect query.
- Display lists of successful and failed actions on `goodbye.php`.

## Testing
- `php -l processes/delete_accounts.php`
- `php -l en/goodbye.php`
- `phpunit` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bead5f0d0c832b8bf9919497dd8979