### PR TITLE
Send JWT on first-time redirects

### DIFF
--- a/processes/login_process_jwt.php
+++ b/processes/login_process_jwt.php
@@ -239,10 +239,9 @@ if ($stmt_credential) {
                     } else {
                         $redirect_url = $app_dashboard_url;
                     }
-
-                    if (!empty($status) && $status !== 'loggedout') {
+                    if ($status === 'firsttime' && !empty($_SESSION['jwt'])) {
                         $delimiter = (strpos($redirect_url, '?') !== false) ? '&' : '?';
-                        $redirect_url .= $delimiter . 'status=' . urlencode($status);
+                        $redirect_url .= $delimiter . 'jwt=' . urlencode($_SESSION['jwt']);
                     }
                     header("Location: $redirect_url");
                     exit();


### PR DESCRIPTION
## Summary
- Restore status handling internally and avoid forwarding it to client apps
- Append JWT token when redirecting first-time users so apps can create accounts

## Testing
- `php -l processes/login_process_jwt.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be9186d4a4832b96fd8ab63c203fec