### PR TITLE
Add logging and unverified-signup fallback for email verification

### DIFF
--- a/en/signup-4.php
+++ b/en/signup-4.php
@@ -41,6 +41,7 @@ $location_watershed = '';
 $latitude = '';
 $longitude = '';
 $emoji_icon = null; // Added variable
+$email_confirm_dt = null;
 
 $sql = "SELECT first_name, location_full, location_watershed, location_lat, location_long, earthling_emoji FROM users_tb WHERE buwana_id = ?";
 $stmt = $buwana_conn->prepare($sql);
@@ -50,6 +51,16 @@ if ($stmt) {
     $stmt->bind_result($first_name, $location_full, $location_watershed, $latitude, $longitude, $earthling_emoji);
     $stmt->fetch();
     $stmt->close();
+}
+
+// 🧠 PART 1b: Fetch email confirmation status
+$stmt_email_confirm = $buwana_conn->prepare("SELECT email_confirm_dt FROM credentials_tb WHERE buwana_id = ?");
+if ($stmt_email_confirm) {
+    $stmt_email_confirm->bind_param('i', $buwana_id);
+    $stmt_email_confirm->execute();
+    $stmt_email_confirm->bind_result($email_confirm_dt);
+    $stmt_email_confirm->fetch();
+    $stmt_email_confirm->close();
 }
 
 // ✅ Check if signup is already completed
@@ -152,7 +163,11 @@ https://github.com/gea-ecobricks/buwana/-->
             </div>
 
             <div style="text-align:center;width:100%;margin:auto;">
-                <p style="color:green;" data-lang-id="001-email-confirmed">✔ Your email is confirmed!</p>
+                <?php if (!empty($email_confirm_dt) && empty($_GET['email_unverified'])): ?>
+                    <p style="color:green;" data-lang-id="001-email-confirmed">✔ Your email is confirmed!</p>
+                <?php else: ?>
+                    <p style="color:#b45309;">⚠️ Email not confirmed yet. You can finish signup, but please verify later.</p>
+                <?php endif; ?>
                 <div id="status-message" style="font-family: 'Arvo';margin-top:15px;"><span data-lang-id="002-now"> Now</span> <?php echo htmlspecialchars($first_name); ?><span data-lang-id="003-now-localize-you"> let's get you localized.</div>
                 <div id="sub-status-message" data-lang-id="004-lets-determine-bioregion" style="font-size:1.3em;padding-top:10px;padding-bottom:10px;">
                     Let's determine your bioregion and local community.


### PR DESCRIPTION
### Motivation
- Surface where Mailgun/SMTP delivery errors are written and give operators a single file to inspect for signup email failures. 
- Let users proceed past the email step when both delivery methods fail while marking their account as unverified so onboarding can continue.

### Description
- Direct `error_log` output for the signup email flow to `logs/signup-3-email.log` by setting `ini_set('error_log', ...)` in `en/signup-3.php` and enable `log_errors`.
- Log Mailgun responses and SMTP fallback success/failure with `error_log` calls inside `sendVerificationCode()` and `backUpSMTPsender()` in `en/signup-3.php`.
- Add an `email_delivery_failed` flag and a UI path on `signup-3.php` that shows a `Continue without verification` button when delivery fails; that button posts `skip_verification` which appends a note to `users_tb.notes` and redirects to `signup-4.php?id=...&email_unverified=1`.
- Update `en/signup-4.php` to query `credentials_tb.email_confirm_dt` and show a green confirmation message when present or a warning banner when the email is unconfirmed or `email_unverified=1` is present.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698059c6fa78832b8ae3cc0b857d074d)